### PR TITLE
Fix visit request duration display on shipment metadata view

### DIFF
--- a/application/frontend/src/app/shipments-metadata/components/base-shipments-metadata-table/base-shipments-metadata-table.component.html
+++ b/application/frontend/src/app/shipments-metadata/components/base-shipments-metadata-table/base-shipments-metadata-table.component.html
@@ -85,7 +85,7 @@
     <th mat-header-cell *matHeaderCellDef mat-sort-header>Duration<span>(mm:ss)</span></th>
     <td mat-cell *matCellDef="let item">
       <ng-container *ngIf="item.visitRequest.duration?.seconds != null; else listNilCharacter">
-        {{ secondsToFormattedTime(+item.visitRequest.duration) }}
+        {{ secondsToFormattedTime(item.visitRequest.duration) }}
       </ng-container>
     </td>
   </ng-container>


### PR DESCRIPTION
On the shipment metadata view, visit request durations always display as "00:00" due to trying to cast the duration object to a number. This removes the casting so durations display correctly.

**Current**
<img width="722" alt="image" src="https://user-images.githubusercontent.com/83362099/192556251-b1f22a89-9bca-40be-9c79-69f8f66f78dc.png">

**This PR**
<img width="722" alt="image" src="https://user-images.githubusercontent.com/83362099/192556313-509d2a09-61a3-47bd-af44-24f6ac2af697.png">
