### PR TITLE
Check for lastTravelSegment before writing to it

### DIFF
--- a/application/frontend/src/app/core/selectors/timeline.selectors.ts
+++ b/application/frontend/src/app/core/selectors/timeline.selectors.ts
@@ -234,7 +234,7 @@ const getTimeline = (
   // to place the depot POI after user visit manipulation (max of last visit end time or vehicle end time)
   // and still be consistent with the timeline
   if (lastTravelSegment) {
-    lastTravelSegment.endTime  = maxLong(vehicleEndTime, lastTravelSegment.startTime);
+    lastTravelSegment.endTime = maxLong(vehicleEndTime, lastTravelSegment.startTime);
   }
 
   // User visit modification introduces potential for overlap that breaks assumptions that would

--- a/application/frontend/src/app/core/selectors/timeline.selectors.ts
+++ b/application/frontend/src/app/core/selectors/timeline.selectors.ts
@@ -233,7 +233,9 @@ const getTimeline = (
   // Ensure the last travel segment ends on the vehicle end time; this is to make it easier for the POIs
   // to place the depot POI after user visit manipulation (max of last visit end time or vehicle end time)
   // and still be consistent with the timeline
-  lastTravelSegment.endTime = maxLong(vehicleEndTime, lastTravelSegment.startTime);
+  if (lastTravelSegment) {
+    lastTravelSegment.endTime  = maxLong(vehicleEndTime, lastTravelSegment.startTime);
+  }
 
   // User visit modification introduces potential for overlap that breaks assumptions that would
   // otherwise have produced a sorted timeline, so make sure the resulting timeline is sorted.


### PR DESCRIPTION
Closes #23

Timeline selector assumes there is always at least one driven travel step, which may not be the case, such as when a vehicle has no start or end location and only one stop to make. Checking for the existence of the last travel step before writing to it allows the timeline to properly support this situation.