### PR TITLE
Handle routes with no drive time and/or no visits in PDF export

### DIFF
--- a/application/frontend/src/app/core/services/pdf-download.service.ts
+++ b/application/frontend/src/app/core/services/pdf-download.service.ts
@@ -17,7 +17,7 @@ import { findPathHeadingAtPointOptimized, simplifyPath } from 'src/app/util';
 import { HttpClient } from '@angular/common/http';
 import { MATERIAL_COLORS } from '.';
 import PreSolveVehicleSelectors from '../selectors/pre-solve-vehicle.selectors';
-import { getVehicleStartingLocation } from '../selectors/map.selectors';
+import { getVehicleStartingLocation, selectBounds } from '../selectors/map.selectors';
 
 @Injectable({
   providedIn: 'root',
@@ -36,14 +36,18 @@ export class PdfDownloadService {
     visitRequests: VisitRequest[]
   ): Observable<{ map: string; routeId: number }[]> {
     return combineLatest([
-      this.mapParametersToStaticMapParameters(),
-      this.store.select(fromConfig.selectMapApiKey),
-      this.store.select(PreSolveVehicleSelectors.selectVehicles),
-      this.getDepotIconUrl(),
-      this.getPickupIconUrl(),
-      this.getDropoffIconUrl(),
+      // Workaround to get around the 6 observable limit of combineLatest
+      combineLatest([
+        this.mapParametersToStaticMapParameters(),
+        this.store.select(fromConfig.selectMapApiKey),
+        this.store.select(PreSolveVehicleSelectors.selectVehicles),
+        this.getDepotIconUrl(),
+        this.getPickupIconUrl(),
+        this.getDropoffIconUrl(),
+      ]),
+      this.store.select(selectBounds)
     ]).pipe(
-      mergeMap(([style, apiKey, vehicles, depotIcon, pickupIcon, dropoffIcon]) => {
+      mergeMap(([[style, apiKey, vehicles, depotIcon, pickupIcon, dropoffIcon], bounds]) => {
         return forkJoin(
           routes.map((route, index) => {
             const routeVisits = visitRequests.filter((vr) => route.visits.includes(vr.id));
@@ -58,27 +62,30 @@ export class PdfDownloadService {
               encodedPath = google.maps.geometry.encoding.encodePath(path);
             }
 
-            const markers = [
-              this.visitToDeliveries(
-                routeVisits.filter((vr) => !vr.pickup),
-                dropoffIcon
-              ),
-              this.visitsToPickups(
-                routeVisits.filter((vr) => vr.pickup),
-                pickupIcon
-              ),
-              this.getRouteStartMarker(route, vehicles, routeVisits, depotIcon),
-              this.getRouteEndMarker(route, vehicles, routeVisits, depotIcon),
-            ];
-
             const params: any = {
               key: apiKey,
               format: 'png',
               size: '600x320',
               scale: '2',
               style,
-              markers,
             };
+
+            if (route.visits.length) {
+              params.markers = [
+                this.visitToDeliveries(
+                  routeVisits.filter((vr) => !vr.pickup),
+                  dropoffIcon
+                ),
+                this.visitsToPickups(
+                  routeVisits.filter((vr) => vr.pickup),
+                  pickupIcon
+                ),
+                this.getRouteStartMarker(route, vehicles, routeVisits, depotIcon),
+                this.getRouteEndMarker(route, vehicles, routeVisits, depotIcon),
+              ];
+            } else {
+              params.visible = `${bounds.getNorthEast().lat()},${bounds.getNorthEast().lng()}|${bounds.getSouthWest().lat()},${bounds.getSouthWest().lng()}`
+            }
 
             if (encodedPath) {
               params.path = `color:${MATERIAL_COLORS.Blue.hex.replace('#', '0x')}FF|weight:2|enc:${encodedPath}`

--- a/application/frontend/src/app/core/services/pdf-download.service.ts
+++ b/application/frontend/src/app/core/services/pdf-download.service.ts
@@ -45,13 +45,13 @@ export class PdfDownloadService {
         this.getPickupIconUrl(),
         this.getDropoffIconUrl(),
       ]),
-      this.store.select(selectBounds)
+      this.store.select(selectBounds),
     ]).pipe(
       mergeMap(([[style, apiKey, vehicles, depotIcon, pickupIcon, dropoffIcon], bounds]) => {
         return forkJoin(
           routes.map((route, index) => {
             const routeVisits = visitRequests.filter((vr) => route.visits.includes(vr.id));
-            
+
             let path;
             let encodedPath;
 
@@ -84,11 +84,16 @@ export class PdfDownloadService {
                 this.getRouteEndMarker(route, vehicles, routeVisits, depotIcon),
               ];
             } else {
-              params.visible = `${bounds.getNorthEast().lat()},${bounds.getNorthEast().lng()}|${bounds.getSouthWest().lat()},${bounds.getSouthWest().lng()}`
+              params.visible = `${bounds.getNorthEast().lat()},${bounds
+                .getNorthEast()
+                .lng()}|${bounds.getSouthWest().lat()},${bounds.getSouthWest().lng()}`;
             }
 
             if (encodedPath) {
-              params.path = `color:${MATERIAL_COLORS.Blue.hex.replace('#', '0x')}FF|weight:2|enc:${encodedPath}`
+              params.path = `color:${MATERIAL_COLORS.Blue.hex.replace(
+                '#',
+                '0x'
+              )}FF|weight:2|enc:${encodedPath}`;
             }
 
             return of(true).pipe(
@@ -101,7 +106,10 @@ export class PdfDownloadService {
 
                 return of(null);
               }),
-              map((vehicleIcon) => vehicleIcon && params.markers.push(this.vehicleHeadingToIcon(vehicleIcon))),
+              map(
+                (vehicleIcon) =>
+                  vehicleIcon && params.markers.push(this.vehicleHeadingToIcon(vehicleIcon))
+              ),
               mergeMap((_) =>
                 this.http.get('https://maps.googleapis.com/maps/api/staticmap', {
                   params,


### PR DESCRIPTION
Closes #26 

Adds support to PDF exports for routes with no drive time and routes with no drive time and no visits. In the event of no driving and no visits, a map of the solution bounds is used.