### PR TITLE
Check for custom map options during PDF generation

### DIFF
--- a/application/frontend/src/app/core/services/pdf-download.service.ts
+++ b/application/frontend/src/app/core/services/pdf-download.service.ts
@@ -182,7 +182,7 @@ export class PdfDownloadService {
   private mapParametersToStaticMapParameters(): Observable<string[]> {
     return this.store.select(fromConfig.selectMapOptions).pipe(
       map((options) => {
-        return options.styles.map((style) => {
+        return (options?.styles || []).map((style) => {
           const feature = `feature:${style.featureType || 'all'}|`;
           const element = style.elementType ? `element:${style.elementType}|` : '';
           const stylers = style.stylers


### PR DESCRIPTION
Addresses #36. Check for the existence of custom map options before trying to parse them into the syntax required for Static Maps API for use with PDF export. Result is a functional PDF export using the default Google Maps style.