### PR TITLE
Copy selected precedence rule shipments to top of list

### DIFF
--- a/application/frontend/src/app/core/containers/pre-solve-shipment-model-settings/pre-solve-shipment-model-settings.component.html
+++ b/application/frontend/src/app/core/containers/pre-solve-shipment-model-settings/pre-solve-shipment-model-settings.component.html
@@ -474,10 +474,11 @@
                 maxBufferPx="400">
                 <mat-option
                   *cdkVirtualFor="
-                    let shipment of scenarioShipments$ | async;
-                    let shipmentIndex = index
+                    let shipment of getPrecedenceRuleFirstIndexOptions(
+                      precedenceRule.value.firstIndex
+                    )
                   "
-                  [value]="shipmentIndex"
+                  [value]="getIndexOfShipment(shipment)"
                   [style.height.px]="48"
                   (onSelectionChange)="
                     precedenceRule.value.firstIndex = getIndexOfShipment(shipment)
@@ -513,7 +514,8 @@
                 <mat-option
                   *cdkVirtualFor="
                     let shipment of getPrecendenceRuleSecondIndexOptions(
-                      precedenceRule.value.firstIndex
+                      precedenceRule.value.firstIndex,
+                      precedenceRule.value.secondIndex
                     )
                   "
                   [value]="getIndexOfShipment(shipment)"

--- a/application/frontend/src/app/core/containers/pre-solve-shipment-model-settings/pre-solve-shipment-model-settings.component.ts
+++ b/application/frontend/src/app/core/containers/pre-solve-shipment-model-settings/pre-solve-shipment-model-settings.component.ts
@@ -769,8 +769,18 @@ export class PreSolveShipmentModelSettingsComponent implements OnInit, OnDestroy
     }
   }
 
-  getPrecendenceRuleSecondIndexOptions(firstIndex: number): Shipment[] {
-    return this.scenarioShipments$.value.filter((_, i) => i !== firstIndex);
+  getPrecedenceRuleFirstIndexOptions(selectedIndex: number): Shipment[] {
+    return [
+      selectedIndex && this.scenarioShipments$.value[selectedIndex],
+      ...this.scenarioShipments$.value,
+    ];
+  }
+
+  getPrecendenceRuleSecondIndexOptions(firstIndex: number, selectedIndex: number): Shipment[] {
+    return [
+      selectedIndex && this.scenarioShipments$.value[selectedIndex],
+      ...this.scenarioShipments$.value.filter((_, i) => i !== firstIndex),
+    ];
   }
 
   getIndexOfShipment(shipment: Shipment): number {


### PR DESCRIPTION
Closes #42

Using virtual scroll containers in conjunction with mat-select is not currently supported by Angular Material. The result is that item selections outside of the rendered list will appear as empty since no valid selection has been made as far as the component is concerned.

To fix the display of precedence rules, this patch copies the current selection to the top of the virtual-scroll list so that it is always "in bounds" and will therefore be rendered.