### PR TITLE
Keep injected solution toggle disabled unless application solution exists

### DIFF
--- a/application/frontend/src/app/core/containers/pre-solve-global-settings/pre-solve-global-settings.component.html
+++ b/application/frontend/src/app/core/containers/pre-solve-global-settings/pre-solve-global-settings.component.html
@@ -55,7 +55,7 @@
     <div class="mat-body-strong">Iterate on solution</div>
     <mat-slide-toggle
       color="primary"
-      [checked]="injectedSolution"
+      [checked]="injectedSolution && (hasSolution$ | async)"
       (change)="toggleInjectedSolution($event)"
       [disabled]="(hasSolution$ | async) === false">
       {{ injectedSolution ? 'On' : 'Off' }}


### PR DESCRIPTION
Partially address #44, with additional fix(es) to come.

Because uploaded injected solutions aren't fully supported in the app, it is possible for the app to check the toggle for using an injected solution while also having it locked from editing. This fix requires that a solution in the application exists before enabling or checking the injected solution toggle.