### PR TITLE
Overwrite empty BreakRules

### DIFF
--- a/application/frontend/src/app/core/components/base-edit-vehicle-dialog/base-edit-vehicle-dialog.component.ts
+++ b/application/frontend/src/app/core/components/base-edit-vehicle-dialog/base-edit-vehicle-dialog.component.ts
@@ -1282,12 +1282,16 @@ export class BaseEditVehicleDialogComponent implements OnChanges, OnInit, OnDest
     this.saveRouteDistanceFormData();
     this.saveRouteDurationFormData();
     this.saveTravelDurationFormData();
+    this.saveBreakRules();
     if (this.usedIfRouteIsEmpty.value) {
       this.store.dispatch(
         PreSolveVehicleActions.selectVehicle({ vehicleId: this.updatedVehicle.id })
       );
     }
     this.updatedVehicle.usedIfRouteIsEmpty = this.usedIfRouteIsEmpty.value;
+  }
+
+  saveBreakRules(): void {
     if (this.breakRequests.value.length) {
       if (!this.updatedVehicle.breakRule) {
         this.updatedVehicle.breakRule = {};
@@ -1296,13 +1300,25 @@ export class BaseEditVehicleDialogComponent implements OnChanges, OnInit, OnDest
         this.breakRequests,
         this.timezoneOffset
       );
+    } else if (this.updatedVehicle.breakRule?.breakRequests) {
+      delete this.updatedVehicle.breakRule.breakRequests;
     }
+
     if (this.frequencyConstraints.value.length) {
       if (!this.updatedVehicle.breakRule) {
         this.updatedVehicle.breakRule = {};
       }
       this.updatedVehicle.breakRule.frequencyConstraints =
         FrequencyConstraintFormComponent.readFormValues(this.frequencyConstraints);
+    } else if (this.updatedVehicle.breakRule?.frequencyConstraints) {
+      delete this.updatedVehicle.breakRule.frequencyConstraints;
+    }
+
+    if (
+      !this.updatedVehicle.breakRule?.breakRequests &&
+      !this.updatedVehicle.breakRule?.frequencyConstraints
+    ) {
+      this.updatedVehicle.breakRule = undefined;
     }
   }
 

--- a/application/frontend/src/app/core/containers/pre-solve-edit-vehicle-dialog/pre-solve-edit-vehicle-dialog.component.ts
+++ b/application/frontend/src/app/core/containers/pre-solve-edit-vehicle-dialog/pre-solve-edit-vehicle-dialog.component.ts
@@ -236,7 +236,7 @@ export class PreSolveEditVehicleDialogComponent implements OnInit {
       vehicle.extraVisitDurationForVisitType = null;
     }
     if (unsetFields.includes(VehicleFormFields.BreakRule)) {
-      vehicle.breakRule = {};
+      vehicle.breakRule = undefined;
     }
     return vehicle;
   }


### PR DESCRIPTION
Previous way of deleting BreakRules was to write an empty object to the store, but since upserts work as a partial update and not a complete overwrite, writing an empty object actually results in those fields not updating. Suggested alternative is to explicitly set those fields as `undefined`, as is done here.
Closes #57 