### PR TITLE
Increase Cloud Run memory

### DIFF
--- a/deployment/fleetrouting-app.tf
+++ b/deployment/fleetrouting-app.tf
@@ -103,7 +103,7 @@ module "cloud_run_fleetrouting_app" {
 
   limits = {
     cpu : "1000m"
-    memory : "256Mi"
+    memory : "512Mi"
   }
   container_concurrency = 80
   timeout_seconds       = 3600


### PR DESCRIPTION
Increase Cloud Run memory to 512 MiB. 

Resolves #60