### PR TITLE
Add better support for allowedVehicleIndices and fix a few bugs in the two-step planner

### DIFF
--- a/examples/two_step_routing/two_step_routing.py
+++ b/examples/two_step_routing/two_step_routing.py
@@ -51,7 +51,7 @@ import dataclasses
 import datetime
 import math
 import re
-from typing import TypeAlias, TypedDict
+from typing import Any, TypeAlias, TypedDict
 
 # A duration in a string format following the protocol buffers specification in
 # https://protobuf.dev/reference/protobuf/google.protobuf/#duration
@@ -248,10 +248,30 @@ class OptimizeToursResponse(TypedDict, total=False):
 
 # pylint: enable=invalid-name
 
-# A key used to group shipments into parking groups. The key contains the
-# parking tag of the shipment (if used), and the delivery time window timestamps
-# (if present).
-_ParkingGroupKey = tuple[str | None, str | None, str | None]
+
+@dataclasses.dataclass(frozen=True)
+class _ParkingGroupKey:
+  """A key used to group shipments into parking groups.
+
+  A parking group is a group of shipments that are delivered from the same
+  parking location and that are planned as a group by the global model. The goal
+  of this class is that shipments with the same key can be grouped in the local
+  and global models.
+
+  Attributes:
+    parking_tag: The tag of the parking location from which the shipment is
+      delivered.
+    start_time: The beginning of the delivery window of the shipment.
+    end_time: The end of the delivery window of the shipment.
+    allowed_vehicle_indices: The list of vehicle indices that can deliver the
+      shipment.
+  """
+
+  parking_tag: str | None = None
+  start_time: str | None = None
+  end_time: str | None = None
+  allowed_vehicle_indices: tuple[int, ...] | None = None
+
 
 # The type of parking location tags. Technically, this is a string, but we use
 # an alias with a different name to make this apparent from type annotations
@@ -450,9 +470,8 @@ class Planner:
     }
 
     for parking_key, group_shipment_indices in self._parking_groups.items():
-      parking_tag, start_time, end_time = parking_key
-      assert parking_tag is not None
-      parking = self._parking_locations[parking_tag]
+      assert parking_key.parking_tag is not None
+      parking = self._parking_locations[parking_key.parking_tag]
       num_shipments = len(group_shipment_indices)
       assert num_shipments > 0
 
@@ -463,9 +482,7 @@ class Planner:
           num_shipments / self._options.min_average_shipments_per_round
       )
       assert max_num_rounds > 0
-      vehicle_label = _make_local_model_vehicle_label(
-          parking_tag, start_time, end_time
-      )
+      vehicle_label = _make_local_model_vehicle_label(parking_key)
       parking_waypoint: Waypoint = {"location": {"latLng": parking.coordinates}}
       group_vehicle_indices = []
       for round_index in range(max_num_rounds):
@@ -489,13 +506,13 @@ class Planner:
               unit: {"maxLoad": str(max_load)}
               for unit, max_load in parking.delivery_load_limits.items()
           }
-        if start_time is not None:
+        if parking_key.start_time is not None:
           vehicle["startTimeWindows"] = [{
-              "startTime": start_time,
+              "startTime": parking_key.start_time,
           }]
-        if end_time is not None:
+        if parking_key.end_time is not None:
           vehicle["endTimeWindows"] = [{
-              "endTime": end_time,
+              "endTime": parking_key.end_time,
           }]
         local_vehicles.append(vehicle)
 
@@ -958,7 +975,7 @@ def validate_request(
           "Shipments delivered via parking must have exactly one delivery"
           " visit request",
           shipment_index,
-          label
+          label,
       )
       continue
 
@@ -969,7 +986,7 @@ def validate_request(
           "Shipments delivered via parking must have at most one delivery time"
           " window",
           shipment_index,
-          label
+          label,
       )
 
   if errors:
@@ -1131,17 +1148,20 @@ def _get_parking_tag_from_local_route(route: ShipmentRoute) -> str:
   return parking_tag
 
 
-def _make_local_model_vehicle_label(
-    parking_tag: str, start_time: TimeString | None, end_time: TimeString | None
-) -> str:
+def _make_local_model_vehicle_label(group_key: _ParkingGroupKey) -> str:
   """Creates a label for a vehicle in the local model."""
-  parts = [parking_tag, " ["]
-  if start_time is not None:
-    parts.append(start_time)
-  if start_time is not None or end_time is not None:
-    parts.append(",")
-  if end_time is not None:
-    parts.append(end_time)
+  parts = [group_key.parking_tag, " ["]
+
+  def add_part_if_not_none(keyword: str, value: Any):
+    if value is not None:
+      if len(parts) > 2:
+        parts.append(" ")
+      parts.append(keyword)
+      parts.append(str(value))
+
+  add_part_if_not_none("start=", group_key.start_time)
+  add_part_if_not_none("end=", group_key.end_time)
+  add_part_if_not_none("vehicles=", group_key.allowed_vehicle_indices)
   parts.append("]")
   return "".join(parts)
 
@@ -1151,7 +1171,7 @@ def _parking_delivery_group_key(
 ) -> _ParkingGroupKey:
   """Creates a key that groups shipments with the same time window and parking."""
   if parking is None:
-    return (None, None, None)
+    return _ParkingGroupKey()
   parking_tag = parking.tag
   start_time = None
   end_time = None
@@ -1160,7 +1180,15 @@ def _parking_delivery_group_key(
   if time_window is not None:
     start_time = time_window.get("startTime")
     end_time = time_window.get("endTime")
-  return (parking_tag, start_time, end_time)
+  allowed_vehicle_indices = shipment.get("allowedVehicleIndices")
+  if allowed_vehicle_indices is not None:
+    allowed_vehicle_indices = tuple(sorted(allowed_vehicle_indices))
+  return _ParkingGroupKey(
+      parking_tag=parking_tag,
+      start_time=start_time,
+      end_time=end_time,
+      allowed_vehicle_indices=allowed_vehicle_indices,
+  )
 
 
 def _update_time_string(

--- a/examples/two_step_routing/two_step_routing_test.py
+++ b/examples/two_step_routing/two_step_routing_test.py
@@ -149,14 +149,14 @@ class PlannerTest(unittest.TestCase):
                   "S007",
                   latlng=(48.86597, 2.34890),
                   duration="150s",
-                  allowed_vehicle_indices=[0, 1],
+                  allowed_vehicle_indices=[0],
                   load_demands={"ore": 1, "wood": 5},
               ),
               _make_shipment(  # 7
                   "S008",
                   latlng=(48.86597, 2.34890),
                   duration="150s",
-                  allowed_vehicle_indices=[0, 1],
+                  allowed_vehicle_indices=[1],
               ),
               _make_shipment(  # 8
                   "S009",
@@ -304,10 +304,10 @@ class PlannerTest(unittest.TestCase):
                       "duration": "150s",
                   }],
                   "label": "4: S005",
-                  "allowedVehicleIndices": [3, 4],
+                  "allowedVehicleIndices": [3],
               },
               {
-                  "allowedVehicleIndices": [3, 4],
+                  "allowedVehicleIndices": [3],
                   "deliveries": [{
                       "arrivalWaypoint": {
                           "location": {
@@ -326,7 +326,7 @@ class PlannerTest(unittest.TestCase):
                   },
               },
               {
-                  "allowedVehicleIndices": [3, 4],
+                  "allowedVehicleIndices": [4],
                   "deliveries": [{
                       "arrivalWaypoint": {
                           "location": {
@@ -345,7 +345,7 @@ class PlannerTest(unittest.TestCase):
                   },
               },
               {
-                  "allowedVehicleIndices": [3, 4],
+                  "allowedVehicleIndices": [5],
                   "deliveries": [{
                       "arrivalWaypoint": {
                           "location": {
@@ -362,7 +362,7 @@ class PlannerTest(unittest.TestCase):
           ],
           "vehicles": [
               {
-                  "label": "P001 []/0",
+                  "label": "P001 [vehicles=(0,)]/0",
                   "endWaypoint": {
                       "location": {
                           "latLng": {
@@ -388,7 +388,9 @@ class PlannerTest(unittest.TestCase):
                   "loadLimits": {"ore": {"maxLoad": "2"}},
               },
               {
-                  "label": "P001 [2023-08-11T12:00:00.000Z,]/0",
+                  "label": (
+                      "P001 [start=2023-08-11T12:00:00.000Z vehicles=(0,)]/0"
+                  ),
                   "endWaypoint": {
                       "location": {
                           "latLng": {
@@ -418,8 +420,8 @@ class PlannerTest(unittest.TestCase):
               },
               {
                   "label": (
-                      "P001 [2023-08-11T14:00:00.000Z,"
-                      "2023-08-11T16:00:00.000Z]/0"
+                      "P001 [start=2023-08-11T14:00:00.000Z"
+                      " end=2023-08-11T16:00:00.000Z vehicles=(0,)]/0"
                   ),
                   "endWaypoint": {
                       "location": {
@@ -452,7 +454,7 @@ class PlannerTest(unittest.TestCase):
                   "loadLimits": {"ore": {"maxLoad": "2"}},
               },
               {
-                  "label": "P002 []/0",
+                  "label": "P002 [vehicles=(0, 1)]/0",
                   "endWaypoint": {
                       "location": {
                           "latLng": {
@@ -489,7 +491,7 @@ class PlannerTest(unittest.TestCase):
                       }
                   },
                   "fixedCost": 10000,
-                  "label": "P002 []/1",
+                  "label": "P002 [vehicles=(0,)]/0",
                   "routeDurationLimit": {"maxDuration": "1800s"},
                   "startWaypoint": {
                       "location": {
@@ -503,6 +505,26 @@ class PlannerTest(unittest.TestCase):
                   "travelMode": 2,
                   "loadLimits": {"ore": {"maxLoad": "2"}},
               },
+              {
+                  "costPerHour": 300,
+                  "costPerKilometer": 60,
+                  "endWaypoint": {
+                      "location": {
+                          "latLng": {"latitude": 48.86482, "longitude": 2.34932}
+                      }
+                  },
+                  "fixedCost": 10000,
+                  "label": "P002 [vehicles=(1,)]/0",
+                  "loadLimits": {"ore": {"maxLoad": "2"}},
+                  "routeDurationLimit": {"maxDuration": "1800s"},
+                  "startWaypoint": {
+                      "location": {
+                          "latLng": {"latitude": 48.86482, "longitude": 2.34932}
+                      }
+                  },
+                  "travelDurationMultiple": 1.0,
+                  "travelMode": 2,
+              },
           ],
       },
       "parent": "my_awesome_project",
@@ -513,7 +535,7 @@ class PlannerTest(unittest.TestCase):
   _LOCAL_RESPONSE_JSON: two_step_routing.OptimizeToursResponse = {
       "routes": [
           {
-              "vehicleLabel": "P001 []/0",
+              "vehicleLabel": "P001 [vehicles=(0,)]/0",
               "vehicleStartTime": "2023-08-11T00:00:00Z",
               "vehicleEndTime": "2023-08-11T00:15:32Z",
               "visits": [
@@ -548,7 +570,9 @@ class PlannerTest(unittest.TestCase):
           },
           {
               "vehicleIndex": 1,
-              "vehicleLabel": "P001 [2023-08-11T12:00:00.000Z,]/0",
+              "vehicleLabel": (
+                  "P001 [start=2023-08-11T12:00:00.000Z vehicles=(0,)]/0"
+              ),
               "vehicleStartTime": "2023-08-11T12:00:00Z",
               "vehicleEndTime": "2023-08-11T12:12:04Z",
               "visits": [{
@@ -574,7 +598,8 @@ class PlannerTest(unittest.TestCase):
           {
               "vehicleIndex": 2,
               "vehicleLabel": (
-                  "P001 [2023-08-11T14:00:00.000Z,2023-08-11T16:00:00.000Z]/0"
+                  "P001 [start=2023-08-11T14:00:00.000Z"
+                  " end=2023-08-11T16:00:00.000Z vehicles=(0,)]/0"
               ),
               "vehicleStartTime": "2023-08-11T14:00:00Z",
               "vehicleEndTime": "2023-08-11T14:12:04Z",
@@ -600,13 +625,49 @@ class PlannerTest(unittest.TestCase):
           },
           {
               "vehicleIndex": 3,
-              "vehicleLabel": "P002 []/0",
+              "vehicleLabel": "P002 [vehicles=(0, 1)]/0",
+              "vehicleStartTime": "2023-08-11T00:00:00Z",
+              "vehicleEndTime": "2023-08-11T00:09:30Z",
+              "visits": [
+                  {
+                      "shipmentIndex": 5,
+                      "startTime": "2023-08-11T00:02:15Z",
+                      "shipmentLabel": "5: S006",
+                  },
+                  {
+                      "shipmentIndex": 4,
+                      "startTime": "2023-08-11T00:04:45Z",
+                      "shipmentLabel": "4: S005",
+                  },
+              ],
+              "transitions": [
+                  {
+                      "totalDuration": "135s",
+                      "startTime": "2023-08-11T00:00:00Z",
+                  },
+                  {
+                      "totalDuration": "0s",
+                      "startTime": "2023-08-11T00:04:45Z",
+                  },
+                  {
+                      "totalDuration": "135s",
+                      "startTime": "2023-08-11T00:07:15Z",
+                  },
+              ],
+              "metrics": {
+                  "totalDuration": "570s",
+              },
+              "routeTotalCost": 10069.94,
+          },
+          {
+              "vehicleIndex": 4,
+              "vehicleLabel": "P002 [vehicles=(0,)]/0",
               "vehicleStartTime": "2023-08-11T00:00:00Z",
               "vehicleEndTime": "2023-08-11T00:06:59Z",
               "visits": [{
-                  "shipmentIndex": 5,
+                  "shipmentIndex": 6,
                   "startTime": "2023-08-11T00:02:15Z",
-                  "shipmentLabel": "5: S006",
+                  "shipmentLabel": "6: S007",
               }],
               "transitions": [
                   {
@@ -624,52 +685,32 @@ class PlannerTest(unittest.TestCase):
               "routeTotalCost": 10057.356666666667,
           },
           {
-              "vehicleIndex": 4,
-              "vehicleLabel": "P002 []/1",
+              "vehicleIndex": 5,
+              "vehicleLabel": "P002 [vehicles=(1,)]/0",
               "vehicleStartTime": "2023-08-11T00:00:00Z",
-              "vehicleEndTime": "2023-08-11T00:12:00Z",
-              "visits": [
-                  {
-                      "shipmentIndex": 7,
-                      "startTime": "2023-08-11T00:02:15Z",
-                      "shipmentLabel": "7: S008",
-                  },
-                  {
-                      "shipmentIndex": 6,
-                      "startTime": "2023-08-11T00:04:45Z",
-                      "shipmentLabel": "6: S007",
-                  },
-                  {
-                      "shipmentIndex": 4,
-                      "startTime": "2023-08-11T00:07:15Z",
-                      "shipmentLabel": "4: S005",
-                  },
-              ],
+              "vehicleEndTime": "2023-08-11T00:06:59Z",
+              "visits": [{
+                  "shipmentIndex": 7,
+                  "startTime": "2023-08-11T00:02:15Z",
+                  "shipmentLabel": "7: S008",
+              }],
               "transitions": [
                   {
                       "totalDuration": "135s",
                       "startTime": "2023-08-11T00:00:00Z",
                   },
                   {
-                      "totalDuration": "0s",
+                      "totalDuration": "134s",
                       "startTime": "2023-08-11T00:04:45Z",
-                  },
-                  {
-                      "totalDuration": "0s",
-                      "startTime": "2023-08-11T00:07:15Z",
-                  },
-                  {
-                      "totalDuration": "135s",
-                      "startTime": "2023-08-11T00:09:45Z",
                   },
               ],
               "metrics": {
-                  "totalDuration": "720s",
+                  "totalDuration": "419s",
               },
-              "routeTotalCost": 10082.44,
+              "routeTotalCost": 10057.356666666667,
           },
       ],
-      "totalCost": 50679.65,
+      "totalCost": 60724.506666666661,
   }
 
   # The expected global model request created by the two-step planner for the
@@ -757,16 +798,16 @@ class PlannerTest(unittest.TestCase):
                               }
                           }
                       },
-                      "duration": "419s",
+                      "duration": "570s",
                   }],
-                  "label": "p:3 S006",
+                  "label": "p:3 S006,S005",
                   "loadDemands": {
                       "ore": {"amount": "2"},
                       "wheat": {"amount": "3"},
                   },
               },
               {
-                  "allowedVehicleIndices": [0, 1],
+                  "allowedVehicleIndices": [0],
                   "deliveries": [{
                       "arrivalWaypoint": {
                           "location": {
@@ -776,13 +817,28 @@ class PlannerTest(unittest.TestCase):
                               }
                           }
                       },
-                      "duration": "720s",
+                      "duration": "419s",
                   }],
-                  "label": "p:4 S008,S007,S005",
+                  "label": "p:4 S007",
                   "loadDemands": {
                       "ore": {"amount": "1"},
                       "wood": {"amount": "5"},
                   },
+              },
+              {
+                  "allowedVehicleIndices": [1],
+                  "deliveries": [{
+                      "arrivalWaypoint": {
+                          "location": {
+                              "latLng": {
+                                  "latitude": 48.86482,
+                                  "longitude": 2.34932,
+                              }
+                          }
+                      },
+                      "duration": "419s",
+                  }],
+                  "label": "p:5 S008",
               },
           ],
           "vehicles": [
@@ -852,59 +908,50 @@ class PlannerTest(unittest.TestCase):
               "vehicleEndTime": "2023-08-11T16:00:00Z",
               "visits": [
                   {
-                      "startTime": "2023-08-11T14:54:13Z",
+                      "startTime": "2023-08-11T15:06:13Z",
                       "shipmentLabel": "s:8 S009",
                   },
                   {
-                      "shipmentIndex": 4,
-                      "startTime": "2023-08-11T14:58:39Z",
-                      "shipmentLabel": "p:3 S006",
-                  },
-                  {
-                      "shipmentIndex": 5,
-                      "startTime": "2023-08-11T15:05:38Z",
-                      "shipmentLabel": "p:4 S008,S007,S005",
-                  },
-                  {
                       "shipmentIndex": 3,
-                      "startTime": "2023-08-11T15:17:38Z",
+                      "startTime": "2023-08-11T15:10:39Z",
                       "shipmentLabel": "p:2 S004",
                   },
                   {
                       "shipmentIndex": 1,
-                      "startTime": "2023-08-11T15:29:42Z",
+                      "startTime": "2023-08-11T15:22:43Z",
                       "shipmentLabel": "p:0 S001,S002",
                   },
                   {
                       "shipmentIndex": 2,
-                      "startTime": "2023-08-11T15:45:14Z",
+                      "startTime": "2023-08-11T15:38:15Z",
                       "shipmentLabel": "p:1 S003",
+                  },
+                  {
+                      "shipmentIndex": 5,
+                      "startTime": "2023-08-11T15:50:19Z",
+                      "shipmentLabel": "p:4 S007",
                   },
               ],
               "transitions": [
                   {
-                      "totalDuration": "24853s",
+                      "totalDuration": "25573s",
                       "startTime": "2023-08-11T08:00:00Z",
                   },
                   {
                       "totalDuration": "116s",
-                      "startTime": "2023-08-11T14:56:43Z",
+                      "startTime": "2023-08-11T15:08:43Z",
                   },
                   {
                       "totalDuration": "0s",
-                      "startTime": "2023-08-11T15:05:38Z",
+                      "startTime": "2023-08-11T15:22:43Z",
                   },
                   {
                       "totalDuration": "0s",
-                      "startTime": "2023-08-11T15:17:38Z",
+                      "startTime": "2023-08-11T15:38:15Z",
                   },
                   {
                       "totalDuration": "0s",
-                      "startTime": "2023-08-11T15:29:42Z",
-                  },
-                  {
-                      "totalDuration": "0s",
-                      "startTime": "2023-08-11T15:45:14Z",
+                      "startTime": "2023-08-11T15:50:19Z",
                   },
                   {
                       "totalDuration": "162s",
@@ -916,9 +963,44 @@ class PlannerTest(unittest.TestCase):
               },
               "routeTotalCost": 481.985,
           },
-          {"vehicleIndex": 1, "vehicleLabel": "V002"},
+          {
+              "vehicleIndex": 1,
+              "vehicleLabel": "V002",
+              "vehicleStartTime": "2023-08-11T08:00:00Z",
+              "vehicleEndTime": "2023-08-11T20:00:00Z",
+              "visits": [
+                  {
+                      "shipmentIndex": 6,
+                      "startTime": "2023-08-11T19:40:49Z",
+                      "shipmentLabel": "p:5 S008",
+                  },
+                  {
+                      "shipmentIndex": 4,
+                      "startTime": "2023-08-11T19:47:48Z",
+                      "shipmentLabel": "p:3 S006,S005",
+                  },
+              ],
+              "transitions": [
+                  {
+                      "totalDuration": "42049s",
+                      "startTime": "2023-08-11T08:00:00Z",
+                  },
+                  {
+                      "totalDuration": "0s",
+                      "startTime": "2023-08-11T19:47:48Z",
+                  },
+                  {
+                      "totalDuration": "162s",
+                      "startTime": "2023-08-11T19:57:18Z",
+                  },
+              ],
+              "metrics": {
+                  "totalDuration": "43200s",
+              },
+              "routeTotalCost": 721.965,
+          },
       ],
-      "totalCost": 481.985,
+      "totalCost": 1203.95,
   }
 
   # The expected merged model request created by the two-step planner for the
@@ -1032,7 +1114,7 @@ class PlannerTest(unittest.TestCase):
                   },
               },
               {
-                  "allowedVehicleIndices": [0, 1],
+                  "allowedVehicleIndices": [0],
                   "deliveries": [{
                       "arrivalWaypoint": {
                           "location": {
@@ -1051,7 +1133,7 @@ class PlannerTest(unittest.TestCase):
                   },
               },
               {
-                  "allowedVehicleIndices": [0, 1],
+                  "allowedVehicleIndices": [1],
                   "deliveries": [{
                       "arrivalWaypoint": {
                           "location": {
@@ -1092,6 +1174,90 @@ class PlannerTest(unittest.TestCase):
                       },
                       "duration": "0s",
                   }],
+                  "label": "P001 arrival",
+              },
+              {
+                  "deliveries": [{
+                      "arrivalWaypoint": {
+                          "location": {
+                              "latLng": {
+                                  "latitude": 48.86482,
+                                  "longitude": 2.34932,
+                              }
+                          }
+                      },
+                      "duration": "0s",
+                  }],
+                  "label": "P001 departure",
+              },
+              {
+                  "deliveries": [{
+                      "arrivalWaypoint": {
+                          "location": {
+                              "latLng": {
+                                  "latitude": 48.86482,
+                                  "longitude": 2.34932,
+                              }
+                          }
+                      },
+                      "duration": "0s",
+                  }],
+                  "label": "P001 arrival",
+              },
+              {
+                  "deliveries": [{
+                      "arrivalWaypoint": {
+                          "location": {
+                              "latLng": {
+                                  "latitude": 48.86482,
+                                  "longitude": 2.34932,
+                              }
+                          }
+                      },
+                      "duration": "0s",
+                  }],
+                  "label": "P001 departure",
+              },
+              {
+                  "deliveries": [{
+                      "arrivalWaypoint": {
+                          "location": {
+                              "latLng": {
+                                  "latitude": 48.86482,
+                                  "longitude": 2.34932,
+                              }
+                          }
+                      },
+                      "duration": "0s",
+                  }],
+                  "label": "P001 arrival",
+              },
+              {
+                  "deliveries": [{
+                      "arrivalWaypoint": {
+                          "location": {
+                              "latLng": {
+                                  "latitude": 48.86482,
+                                  "longitude": 2.34932,
+                              }
+                          }
+                      },
+                      "duration": "0s",
+                  }],
+                  "label": "P001 departure",
+              },
+              {
+                  "deliveries": [{
+                      "arrivalWaypoint": {
+                          "location": {
+                              "latLng": {
+                                  "latitude": 48.86482,
+                                  "longitude": 2.34932,
+                              }
+                          }
+                      },
+                      "duration": "0s",
+                  }],
                   "label": "P002 arrival",
               },
               {
@@ -1148,7 +1314,7 @@ class PlannerTest(unittest.TestCase):
                       },
                       "duration": "0s",
                   }],
-                  "label": "P001 arrival",
+                  "label": "P002 arrival",
               },
               {
                   "deliveries": [{
@@ -1162,63 +1328,7 @@ class PlannerTest(unittest.TestCase):
                       },
                       "duration": "0s",
                   }],
-                  "label": "P001 departure",
-              },
-              {
-                  "deliveries": [{
-                      "arrivalWaypoint": {
-                          "location": {
-                              "latLng": {
-                                  "latitude": 48.86482,
-                                  "longitude": 2.34932,
-                              }
-                          }
-                      },
-                      "duration": "0s",
-                  }],
-                  "label": "P001 arrival",
-              },
-              {
-                  "deliveries": [{
-                      "arrivalWaypoint": {
-                          "location": {
-                              "latLng": {
-                                  "latitude": 48.86482,
-                                  "longitude": 2.34932,
-                              }
-                          }
-                      },
-                      "duration": "0s",
-                  }],
-                  "label": "P001 departure",
-              },
-              {
-                  "deliveries": [{
-                      "arrivalWaypoint": {
-                          "location": {
-                              "latLng": {
-                                  "latitude": 48.86482,
-                                  "longitude": 2.34932,
-                              }
-                          }
-                      },
-                      "duration": "0s",
-                  }],
-                  "label": "P001 arrival",
-              },
-              {
-                  "deliveries": [{
-                      "arrivalWaypoint": {
-                          "location": {
-                              "latLng": {
-                                  "latitude": 48.86482,
-                                  "longitude": 2.34932,
-                              }
-                          }
-                      },
-                      "duration": "0s",
-                  }],
-                  "label": "P001 departure",
+                  "label": "P002 departure",
               },
           ],
           "vehicles": [
@@ -1287,61 +1397,50 @@ class PlannerTest(unittest.TestCase):
               "transitions": [
                   {
                       "startTime": "2023-08-11T08:00:00Z",
-                      "totalDuration": "24853s",
+                      "totalDuration": "25573s",
                   },
                   {
-                      "startTime": "2023-08-11T14:56:43Z",
+                      "startTime": "2023-08-11T15:08:43Z",
                       "totalDuration": "116s",
                   },
                   {
-                      "startTime": "2023-08-11T14:58:39Z",
-                      "totalDuration": "135s",
-                  },
-                  {
-                      "startTime": "2023-08-11T15:03:24Z",
-                      "totalDuration": "134s",
-                  },
-                  {"startTime": "2023-08-11T15:05:38Z", "totalDuration": "0s"},
-                  {
-                      "startTime": "2023-08-11T15:05:38Z",
-                      "totalDuration": "135s",
-                  },
-                  {"startTime": "2023-08-11T15:10:23Z", "totalDuration": "0s"},
-                  {"startTime": "2023-08-11T15:12:53Z", "totalDuration": "0s"},
-                  {
-                      "startTime": "2023-08-11T15:15:23Z",
-                      "totalDuration": "135s",
-                  },
-                  {"startTime": "2023-08-11T15:17:38Z", "totalDuration": "0s"},
-                  {
-                      "startTime": "2023-08-11T15:17:38Z",
+                      "startTime": "2023-08-11T15:10:39Z",
                       "totalDuration": "536s",
                   },
                   {
-                      "startTime": "2023-08-11T15:27:34Z",
+                      "startTime": "2023-08-11T15:20:35Z",
                       "totalDuration": "128s",
                   },
-                  {"startTime": "2023-08-11T15:29:42Z", "totalDuration": "0s"},
+                  {"startTime": "2023-08-11T15:22:43Z", "totalDuration": "0s"},
                   {
-                      "startTime": "2023-08-11T15:29:42Z",
+                      "startTime": "2023-08-11T15:22:43Z",
                       "totalDuration": "157s",
                   },
                   {
-                      "startTime": "2023-08-11T15:34:19Z",
+                      "startTime": "2023-08-11T15:27:20Z",
                       "totalDuration": "377s",
                   },
                   {
-                      "startTime": "2023-08-11T15:43:06Z",
+                      "startTime": "2023-08-11T15:36:07Z",
                       "totalDuration": "128s",
                   },
-                  {"startTime": "2023-08-11T15:45:14Z", "totalDuration": "0s"},
+                  {"startTime": "2023-08-11T15:38:15Z", "totalDuration": "0s"},
                   {
-                      "startTime": "2023-08-11T15:45:14Z",
+                      "startTime": "2023-08-11T15:38:15Z",
                       "totalDuration": "536s",
                   },
                   {
-                      "startTime": "2023-08-11T15:55:10Z",
+                      "startTime": "2023-08-11T15:48:11Z",
                       "totalDuration": "128s",
+                  },
+                  {"startTime": "2023-08-11T15:50:19Z", "totalDuration": "0s"},
+                  {
+                      "startTime": "2023-08-11T15:50:19Z",
+                      "totalDuration": "135s",
+                  },
+                  {
+                      "startTime": "2023-08-11T15:55:04Z",
+                      "totalDuration": "134s",
                   },
                   {
                       "startTime": "2023-08-11T15:57:18Z",
@@ -1356,101 +1455,147 @@ class PlannerTest(unittest.TestCase):
                   {
                       "shipmentIndex": 8,
                       "shipmentLabel": "S009",
-                      "startTime": "2023-08-11T14:54:13Z",
+                      "startTime": "2023-08-11T15:06:13Z",
                   },
                   {
                       "shipmentIndex": 9,
-                      "shipmentLabel": "P002 arrival",
-                      "startTime": "2023-08-11T14:58:39Z",
-                  },
-                  {
-                      "shipmentIndex": 5,
-                      "shipmentLabel": "S006",
-                      "startTime": "2023-08-11T15:00:54Z",
-                  },
-                  {
-                      "shipmentIndex": 10,
-                      "shipmentLabel": "P002 departure",
-                      "startTime": "2023-08-11T15:05:38Z",
-                  },
-                  {
-                      "shipmentIndex": 11,
-                      "shipmentLabel": "P002 arrival",
-                      "startTime": "2023-08-11T15:05:38Z",
-                  },
-                  {
-                      "shipmentIndex": 7,
-                      "shipmentLabel": "S008",
-                      "startTime": "2023-08-11T15:07:53Z",
-                  },
-                  {
-                      "shipmentIndex": 6,
-                      "shipmentLabel": "S007",
-                      "startTime": "2023-08-11T15:10:23Z",
-                  },
-                  {
-                      "shipmentIndex": 4,
-                      "shipmentLabel": "S005",
-                      "startTime": "2023-08-11T15:12:53Z",
-                  },
-                  {
-                      "shipmentIndex": 12,
-                      "shipmentLabel": "P002 departure",
-                      "startTime": "2023-08-11T15:17:38Z",
-                  },
-                  {
-                      "shipmentIndex": 13,
                       "shipmentLabel": "P001 arrival",
-                      "startTime": "2023-08-11T15:17:38Z",
+                      "startTime": "2023-08-11T15:10:39Z",
                   },
                   {
                       "shipmentIndex": 3,
                       "shipmentLabel": "S004",
-                      "startTime": "2023-08-11T15:26:34Z",
+                      "startTime": "2023-08-11T15:19:35Z",
                   },
                   {
-                      "shipmentIndex": 14,
+                      "shipmentIndex": 10,
                       "shipmentLabel": "P001 departure",
-                      "startTime": "2023-08-11T15:29:42Z",
+                      "startTime": "2023-08-11T15:22:43Z",
                   },
                   {
-                      "shipmentIndex": 15,
+                      "shipmentIndex": 11,
                       "shipmentLabel": "P001 arrival",
-                      "startTime": "2023-08-11T15:29:42Z",
+                      "startTime": "2023-08-11T15:22:43Z",
                   },
                   {
                       "shipmentIndex": 0,
                       "shipmentLabel": "S001",
-                      "startTime": "2023-08-11T15:32:19Z",
+                      "startTime": "2023-08-11T15:25:20Z",
                   },
                   {
                       "shipmentIndex": 1,
                       "shipmentLabel": "S002",
-                      "startTime": "2023-08-11T15:40:36Z",
+                      "startTime": "2023-08-11T15:33:37Z",
                   },
                   {
-                      "shipmentIndex": 16,
+                      "shipmentIndex": 12,
                       "shipmentLabel": "P001 departure",
-                      "startTime": "2023-08-11T15:45:14Z",
+                      "startTime": "2023-08-11T15:38:15Z",
                   },
                   {
-                      "shipmentIndex": 17,
+                      "shipmentIndex": 13,
                       "shipmentLabel": "P001 arrival",
-                      "startTime": "2023-08-11T15:45:14Z",
+                      "startTime": "2023-08-11T15:38:15Z",
                   },
                   {
                       "shipmentIndex": 2,
                       "shipmentLabel": "S003",
-                      "startTime": "2023-08-11T15:54:10Z",
+                      "startTime": "2023-08-11T15:47:11Z",
                   },
                   {
-                      "shipmentIndex": 18,
+                      "shipmentIndex": 14,
                       "shipmentLabel": "P001 departure",
+                      "startTime": "2023-08-11T15:50:19Z",
+                  },
+                  {
+                      "shipmentIndex": 15,
+                      "shipmentLabel": "P002 arrival",
+                      "startTime": "2023-08-11T15:50:19Z",
+                  },
+                  {
+                      "shipmentIndex": 6,
+                      "shipmentLabel": "S007",
+                      "startTime": "2023-08-11T15:52:34Z",
+                  },
+                  {
+                      "shipmentIndex": 16,
+                      "shipmentLabel": "P002 departure",
                       "startTime": "2023-08-11T15:57:18Z",
                   },
               ],
           },
-          {"vehicleIndex": 1, "vehicleLabel": "V002"},
+          {
+              "routeTotalCost": 721.965,
+              "transitions": [
+                  {
+                      "startTime": "2023-08-11T08:00:00Z",
+                      "totalDuration": "42049s",
+                  },
+                  {
+                      "startTime": "2023-08-11T19:40:49Z",
+                      "totalDuration": "135s",
+                  },
+                  {
+                      "startTime": "2023-08-11T19:45:34Z",
+                      "totalDuration": "134s",
+                  },
+                  {"startTime": "2023-08-11T19:47:48Z", "totalDuration": "0s"},
+                  {
+                      "startTime": "2023-08-11T19:47:48Z",
+                      "totalDuration": "135s",
+                  },
+                  {"startTime": "2023-08-11T19:52:33Z", "totalDuration": "0s"},
+                  {
+                      "startTime": "2023-08-11T19:55:03Z",
+                      "totalDuration": "135s",
+                  },
+                  {
+                      "startTime": "2023-08-11T19:57:18Z",
+                      "totalDuration": "162s",
+                  },
+              ],
+              "vehicleEndTime": "2023-08-11T20:00:00Z",
+              "vehicleIndex": 1,
+              "vehicleLabel": "V002",
+              "vehicleStartTime": "2023-08-11T08:00:00Z",
+              "visits": [
+                  {
+                      "shipmentIndex": 17,
+                      "shipmentLabel": "P002 arrival",
+                      "startTime": "2023-08-11T19:40:49Z",
+                  },
+                  {
+                      "shipmentIndex": 7,
+                      "shipmentLabel": "S008",
+                      "startTime": "2023-08-11T19:43:04Z",
+                  },
+                  {
+                      "shipmentIndex": 18,
+                      "shipmentLabel": "P002 departure",
+                      "startTime": "2023-08-11T19:47:48Z",
+                  },
+                  {
+                      "shipmentIndex": 19,
+                      "shipmentLabel": "P002 arrival",
+                      "startTime": "2023-08-11T19:47:48Z",
+                  },
+                  {
+                      "shipmentIndex": 5,
+                      "shipmentLabel": "S006",
+                      "startTime": "2023-08-11T19:50:03Z",
+                  },
+                  {
+                      "shipmentIndex": 4,
+                      "shipmentLabel": "S005",
+                      "startTime": "2023-08-11T19:52:33Z",
+                  },
+                  {
+                      "shipmentIndex": 20,
+                      "shipmentLabel": "P002 departure",
+                      "startTime": "2023-08-11T19:57:18Z",
+                  },
+              ],
+          },
       ]
   }
 
@@ -1766,7 +1911,8 @@ class GetParkingTagFromLocalRouteTest(unittest.TestCase):
         two_step_routing._get_parking_tag_from_local_route(
             {
                 "vehicleLabel": (
-                    "P001 [2023-08-11T14:00:00.000Z,2023-08-11T16:00:00.000Z]/0"
+                    "P001 [start=2023-08-11T14:00:00.000Z"
+                    " end=2023-08-11T16:00:00.000Z]/0"
                 )
             },
         ),
@@ -1777,39 +1923,73 @@ class GetParkingTagFromLocalRouteTest(unittest.TestCase):
 class MakeLocalModelVehicleLabelTest(unittest.TestCase):
   """Tests for _make_local_delivery_model_vehicle_label."""
 
+  maxDiff = None
+
   def test_parking_tag_only(self):
     self.assertEqual(
-        two_step_routing._make_local_model_vehicle_label("P123", None, None),
+        two_step_routing._make_local_model_vehicle_label(
+            two_step_routing._ParkingGroupKey("P123")
+        ),
         "P123 []",
     )
 
   def test_parking_tag_and_start_time(self):
     self.assertEqual(
         two_step_routing._make_local_model_vehicle_label(
-            "P123", "2023-08-11T00:00:00.000Z", None
+            two_step_routing._ParkingGroupKey(
+                "P123", "2023-08-11T00:00:00.000Z"
+            )
         ),
-        "P123 [2023-08-11T00:00:00.000Z,]",
+        "P123 [start=2023-08-11T00:00:00.000Z]",
     )
 
   def test_parking_tag_and_end_time(self):
     self.assertEqual(
         two_step_routing._make_local_model_vehicle_label(
-            "P123", None, "2023-08-11T00:00:00.000Z"
+            two_step_routing._ParkingGroupKey(
+                "P123", None, "2023-08-11T00:00:00.000Z"
+            )
         ),
-        "P123 [,2023-08-11T00:00:00.000Z]",
+        "P123 [end=2023-08-11T00:00:00.000Z]",
     )
 
   def test_parking_tag_and_start_and_end_time(self):
     self.assertEqual(
         two_step_routing._make_local_model_vehicle_label(
-            "P123", "2023-08-11T00:00:00.000Z", "2023-08-11T08:00:00.000Z"
+            two_step_routing._ParkingGroupKey(
+                "P123", "2023-08-11T00:00:00.000Z", "2023-08-11T08:00:00.000Z"
+            )
         ),
-        "P123 [2023-08-11T00:00:00.000Z,2023-08-11T08:00:00.000Z]",
+        "P123 [start=2023-08-11T00:00:00.000Z end=2023-08-11T08:00:00.000Z]",
+    )
+
+  def test_parking_tag_and_allowed_vehicles(self):
+    self.assertEqual(
+        two_step_routing._make_local_model_vehicle_label(
+            two_step_routing._ParkingGroupKey("P123", None, None, (0, 1, 2))
+        ),
+        "P123 [vehicles=(0, 1, 2)]",
+    )
+
+  def test_parking_tag_times_and_allowed_vehicles(self):
+    self.assertEqual(
+        two_step_routing._make_local_model_vehicle_label(
+            two_step_routing._ParkingGroupKey(
+                "P123",
+                "2023-08-11T00:00:00.000Z",
+                "2023-08-11T08:00:00.000Z",
+                (0, 1, 2),
+            )
+        ),
+        "P123 [start=2023-08-11T00:00:00.000Z end=2023-08-11T08:00:00.000Z"
+        " vehicles=(0, 1, 2)]",
     )
 
 
 class ParkingDeliveryGroupTest(unittest.TestCase):
   """Tests for _parking_delivery_group_key."""
+
+  maxDiff = None
 
   _START_TIME = "2023-08-09T12:12:00.000Z"
   _END_TIME = "2023-08-09T12:45:32.000Z"
@@ -1856,6 +2036,17 @@ class ParkingDeliveryGroupTest(unittest.TestCase):
           }],
       }],
   }
+  _SHIPMENT_ALLOWED_VEHICLES: two_step_routing.Shipment = {
+      "deliveries": [{
+          "arrivalWaypoint": {
+              "location": {
+                  "latLng": {"latitude": 35.7669, "longitude": 139.7286}
+              }
+          },
+      }],
+      "label": "2023081000001",
+      "allowedVehicleIndices": [0, 5, 2],
+  }
 
   _PARKING_LOCATION = two_step_routing.ParkingLocation(
       coordinates={"latitude": 35.7668, "longitude": 139.7285}, tag="P1234"
@@ -1867,10 +2058,11 @@ class ParkingDeliveryGroupTest(unittest.TestCase):
         self._SHIPMENT_TIME_WINDOW_START,
         self._SHIPMENT_TIME_WINDOW_END,
         self._SHIPMENT_TIME_WINDOW_START_END,
+        self._SHIPMENT_ALLOWED_VEHICLES,
     ):
       self.assertEqual(
           two_step_routing._parking_delivery_group_key(shipment, None),
-          (None, None, None),
+          two_step_routing._ParkingGroupKey(),
       )
 
   def test_with_parking_and_no_time_window(self):
@@ -1878,7 +2070,7 @@ class ParkingDeliveryGroupTest(unittest.TestCase):
         two_step_routing._parking_delivery_group_key(
             self._SHIPMENT_NO_TIME_WINDOW, self._PARKING_LOCATION
         ),
-        ("P1234", None, None),
+        two_step_routing._ParkingGroupKey("P1234"),
     )
 
   def test_with_parking_and_time_window_start(self):
@@ -1886,7 +2078,7 @@ class ParkingDeliveryGroupTest(unittest.TestCase):
         two_step_routing._parking_delivery_group_key(
             self._SHIPMENT_TIME_WINDOW_START, self._PARKING_LOCATION
         ),
-        ("P1234", self._START_TIME, None),
+        two_step_routing._ParkingGroupKey("P1234", self._START_TIME, None),
     )
 
   def test_with_parking_and_time_window_end(self):
@@ -1894,7 +2086,7 @@ class ParkingDeliveryGroupTest(unittest.TestCase):
         two_step_routing._parking_delivery_group_key(
             self._SHIPMENT_TIME_WINDOW_END, self._PARKING_LOCATION
         ),
-        ("P1234", None, self._END_TIME),
+        two_step_routing._ParkingGroupKey("P1234", None, self._END_TIME),
     )
 
   def test_with_parking_and_time_window_start_end(self):
@@ -1902,7 +2094,22 @@ class ParkingDeliveryGroupTest(unittest.TestCase):
         two_step_routing._parking_delivery_group_key(
             self._SHIPMENT_TIME_WINDOW_START_END, self._PARKING_LOCATION
         ),
-        ("P1234", self._START_TIME, self._END_TIME),
+        two_step_routing._ParkingGroupKey(
+            "P1234", self._START_TIME, self._END_TIME
+        ),
+    )
+
+  def test_with_allowed_vehicles(self):
+    self.assertEqual(
+        two_step_routing._parking_delivery_group_key(
+            self._SHIPMENT_ALLOWED_VEHICLES, self._PARKING_LOCATION
+        ),
+        two_step_routing._ParkingGroupKey(
+            "P1234",
+            None,
+            None,
+            (0, 2, 5),
+        ),
     )
 
 

--- a/examples/two_step_routing/two_step_routing_test.py
+++ b/examples/two_step_routing/two_step_routing_test.py
@@ -18,6 +18,7 @@ def _make_shipment(
     delivery_start: two_step_routing.TimeString | None = None,
     delivery_end: two_step_routing.TimeString | None = None,
     load_demands: Mapping[str, int] | None = None,
+    cost_per_vehicle: Mapping[int, float] | None = None,
 ) -> two_step_routing.Shipment:
   delivery = {
       "arrivalWaypoint": {
@@ -49,6 +50,10 @@ def _make_shipment(
     shipment["loadDemands"] = {
         unit: {"amount": str(amount)} for unit, amount in load_demands.items()
     }
+  if cost_per_vehicle is not None:
+    vehicle_indices, costs = zip(*cost_per_vehicle.items())
+    shipment["costsPerVehicle"] = list(costs)
+    shipment["costsPerVehicleIndices"] = list(vehicle_indices)
   return shipment
 
 
@@ -110,6 +115,7 @@ class PlannerTest(unittest.TestCase):
                   latlng=(48.86471, 2.34901),
                   duration="120s",
                   allowed_vehicle_indices=[0],
+                  cost_per_vehicle={0: 100, 1: 200},
               ),
               _make_shipment(  # 1
                   "S002",
@@ -750,6 +756,8 @@ class PlannerTest(unittest.TestCase):
                       },
                       "duration": "932s",
                   }],
+                  "costsPerVehicle": [100, 200],
+                  "costsPerVehicleIndices": [0, 1],
                   "label": "p:0 S001,S002",
               },
               {
@@ -1026,6 +1034,8 @@ class PlannerTest(unittest.TestCase):
                       "duration": "120s",
                   }],
                   "label": "S001",
+                  "costsPerVehicle": [100, 200],
+                  "costsPerVehicleIndices": [0, 1],
               },
               {
                   "allowedVehicleIndices": [0],


### PR DESCRIPTION
1. Better handle allowedVehicleIndices in the two-step planner:
   
   The original version used the intersection of allowed vehicle indices
   for all shipments served from the parking location. When there are
   significant variations in the allowed vehicles among the shipments, this
   may lead to situations where the set of vehicles that can serve the
   parking location is empty.

   The modified version creates a new parking location visit for each group
   of allowed vehicle indices used with the parking location. The new
   version is equivalent to the original one when allowed vehicle indices
   are not used, but it can create more shipments in the global model when
   many different sets of allowed vehicles are used.

2. Fixed a couple of bugs discovered by more thorough testing:

   - delivery time windows for parking locations in the global model could
     underflow or overflow the global time limit of the model when
     shipments have delivery time windows that start and end at the same
     time as the global time limit.
   - fixed how costsPerVehicle are transferred to the global model.
   - fixed an invalid parser of shipment indices from the local model when
     copying skipped shipments to the merged model.