### PR TITLE
Add IAP service account

### DIFF
--- a/deployment/iap.tf
+++ b/deployment/iap.tf
@@ -2,6 +2,5 @@
 # https://cloud.google.com/iap/docs/enabling-cloud-run
 resource "google_project_service_identity" "iap_sa" {
   provider = google-beta
-  project  = module.project.project_id
   service  = "iap.googleapis.com"
 }

--- a/deployment/iap.tf
+++ b/deployment/iap.tf
@@ -1,0 +1,7 @@
+# IAP service account, required to enable IAP for Cloud Run
+# https://cloud.google.com/iap/docs/enabling-cloud-run
+resource "google_project_service_identity" "iap_sa" {
+  provider = google-beta
+  project  = module.project.project_id
+  service  = "iap.googleapis.com"
+}


### PR DESCRIPTION
Add IAP service account resource, required to enable IAP for Cloud Run.

Reference: <https://cloud.google.com/iap/docs/enabling-cloud-run>