### PR TITLE
fix: don't camel case null objects

### DIFF
--- a/application/frontend/src/app/core/services/dispatcher.service.ts
+++ b/application/frontend/src/app/core/services/dispatcher.service.ts
@@ -60,7 +60,7 @@ export class DispatcherService {
   }
 
   private convertProtoFieldNamesToCamelCase(obj: any, parentField: string = null): any {
-    if (typeof obj !== 'object') {
+    if (typeof obj !== 'object' || obj === null) {
       return obj;
     }
     if (Array.isArray(obj)) {


### PR DESCRIPTION
Ignore null objects when converting uploaded files to camel case.