### PR TITLE
Multi entity info windows

### DIFF
--- a/application/frontend/src/app/core/actions/map.actions.ts
+++ b/application/frontend/src/app/core/actions/map.actions.ts
@@ -58,3 +58,5 @@ export const setLayerVisible = createAction(
   '[Map] Set Layer Visible',
   props<{ layerId: MapLayerId; visible: boolean }>()
 );
+
+export const setZoomLevel = createAction('[Map] Set Zoom Level', props<{ zoom: number }>());

--- a/application/frontend/src/app/core/actions/ui.actions.ts
+++ b/application/frontend/src/app/core/actions/ui.actions.ts
@@ -15,12 +15,18 @@ limitations under the License.
 */
 
 import { createAction, props } from '@ngrx/store';
+import { ILatLng } from '../models';
 
 export const mapVehicleClicked = createAction('[UI] Map Vehicle Clicked', props<{ id: number }>());
 
 export const mapVisitRequestClicked = createAction(
   '[UI] Map Visit Request Clicked',
   props<{ id: number }>()
+);
+
+export const mapMarkerClicked = createAction(
+  '[UI] Map Marker Clicked',
+  props<{ position: ILatLng | null }>()
 );
 
 export const changeSplitSizes = createAction(

--- a/application/frontend/src/app/core/components/base-vehicle-info-window/base-vehicle-info-window.component.html
+++ b/application/frontend/src/app/core/components/base-vehicle-info-window/base-vehicle-info-window.component.html
@@ -22,10 +22,12 @@
   <div class="mr-1">Max load:</div>
   <div ngClass="d-flex flex-column">
     <div *ngFor="let load of ObjectKeys(route.metrics?.maxLoads); let first = first">
-      <span class="strong"
-        >{{ route.metrics.maxLoads[load].amount }} / {{ vehicle.loadLimits[load].maxLoad }}
-        {{ load }}</span
-      >
+      <div *ngIf="vehicle.loadLimits[load]">
+        <span class="strong"
+          >{{ route.metrics.maxLoads[load].amount }} / {{ vehicle.loadLimits[load].maxLoad }}
+          {{ load }}</span
+        >
+      </div>
     </div>
   </div>
 </div>

--- a/application/frontend/src/app/core/containers/index.ts
+++ b/application/frontend/src/app/core/containers/index.ts
@@ -25,6 +25,7 @@ export * from './main-nav/main-nav.component';
 export * from './map-wrapper/map-wrapper.component';
 export * from './map/map.component';
 export * from './metadata-control-bar/metadata-control-bar.component';
+export * from './multiselect-info-window/multiselect-info-window.component';
 export * from './point-of-interest-drag/point-of-interest-drag.component';
 export * from './post-solve-message/post-solve-message.component';
 export * from './post-solve-metrics/post-solve-metrics.component';

--- a/application/frontend/src/app/core/containers/map/map.component.spec.ts
+++ b/application/frontend/src/app/core/containers/map/map.component.spec.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
+import { Subject } from 'rxjs';
 import { MockMap } from 'src/test/google-maps-mocks';
 import { MockInfoWindowService, MockLayerService } from 'src/test/service-mocks';
 import * as fromConfig from '../../selectors/config.selectors';
@@ -96,6 +97,7 @@ describe('MapComponent', () => {
       this.map = new MockMap();
     }
     map: MockMap;
+    zoomChanged$ = new Subject<number>();
   }
 
   beforeEach(async () => {

--- a/application/frontend/src/app/core/containers/map/map.component.ts
+++ b/application/frontend/src/app/core/containers/map/map.component.ts
@@ -50,6 +50,7 @@ import {
   MATERIAL_COLORS,
   VehicleInfoWindowService,
   VisitRequestInfoWindowService,
+  MultiselectInfoWindowService,
 } from '../../services';
 import { DepotLayer } from '../../services/depot-layer.service';
 import { MapService } from '../../services/map.service';
@@ -94,7 +95,8 @@ export class MapComponent implements OnInit, OnDestroy {
     private preSolveVehicleLayer: PreSolveVehicleLayer,
     private preSolveVisitRequestLayer: PreSolveVisitRequestLayer,
     public vehicleInfoWindowService: VehicleInfoWindowService,
-    public visitRequestInfoWindowService: VisitRequestInfoWindowService
+    public visitRequestInfoWindowService: VisitRequestInfoWindowService,
+    public multiselectInfoWindowService: MultiselectInfoWindowService
   ) {}
 
   ngOnInit(): void {

--- a/application/frontend/src/app/core/containers/map/map.component.ts
+++ b/application/frontend/src/app/core/containers/map/map.component.ts
@@ -148,6 +148,10 @@ export class MapComponent implements OnInit, OnDestroy {
       this.store.pipe(select(selectPage)).subscribe((page) => {
         this.page = page;
         this.changeDetector.markForCheck();
+      }),
+
+      this.mapService.zoomChanged$.subscribe((zoom) => {
+        this.store.dispatch(MapActions.setZoomLevel({ zoom }));
       })
     );
 

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -1,1 +1,12 @@
-<p>multiselect-info-window works!</p>
+<div class="info-window-containers">
+  <div *ngFor="let selection of selections">
+      @switch (selection.type) {
+          @case ('VEHICLE') {
+            <app-vehicle-info-window [vehicleId]="selection.id"></app-vehicle-info-window>
+          }
+          @case ('VISIT_REQUEST') {
+            <div>TODO: visit request</div>
+          }
+      }
+  </div>
+</div>

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -1,23 +1,28 @@
-<div class="windows-container">
-  <button
-    mat-icon-button
-    aria-label="Previous"
-    (click)="previous()"
-    [disabled]="currentIndex === 0 || selections.length === 0">
-    <mat-icon>chevron_left</mat-icon>
-  </button>
-  <div *ngIf="currentSelection">
-    @switch (currentSelection.type) { @case ('VEHICLE') {
-    <app-vehicle-info-window [vehicleId]="currentSelection.id"></app-vehicle-info-window>
-    } @case ('VISIT_REQUEST') {
-    <div>TODO: visit request</div>
-    } }
+<div class="window-container">
+  <div class="info-container">
+    <button
+      mat-icon-button
+      aria-label="Previous"
+      (click)="previous()"
+      [disabled]="currentIndex === 0 || selections.length === 0">
+      <mat-icon>chevron_left</mat-icon>
+    </button>
+    <div *ngIf="currentSelection">
+      @switch (currentSelection.type) { @case ('VEHICLE') {
+      <app-vehicle-info-window [vehicleId]="currentSelection.id"></app-vehicle-info-window>
+      } @case ('VISIT_REQUEST') {
+      <div>TODO: visit request</div>
+      } }
+    </div>
+    <button
+      mat-icon-button
+      aria-label="Next"
+      (click)="next()"
+      [disabled]="currentIndex === selections.length - 1 || selections.length === 0">
+      <mat-icon>chevron_right</mat-icon>
+    </button>
   </div>
-  <button
-    mat-icon-button
-    aria-label="Next"
-    (click)="next()"
-    [disabled]="currentIndex === selections.length - 1 || selections.length === 0">
-    <mat-icon>chevron_right</mat-icon>
-  </button>
+  <div class="selection-count">
+    {{ selections.length ? currentIndex + 1 : 0 }} / {{ selections.length }}
+  </div>
 </div>

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -7,8 +7,8 @@
       [disabled]="currentIndex === 0 || selections.length === 0">
       <mat-icon>chevron_left</mat-icon>
     </button>
-    <div *ngIf="currentSelection" class="selection-window">
-      @switch (currentSelection.type) { @case ('VEHICLE') {
+    <div class="selection-window">
+      @switch (currentSelection?.type) { @case ('VEHICLE') {
       <app-vehicle-info-window [vehicleId]="currentSelection.id"></app-vehicle-info-window>
       } @case ('VISIT_REQUEST') {
       <div>TODO: visit request</div>

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -1,6 +1,7 @@
 <div class="window-container">
   <div class="info-container">
     <button
+      *ngIf="selections.length > 1"
       mat-icon-button
       aria-label="Previous"
       (click)="previous()"
@@ -16,6 +17,7 @@
       } }
     </div>
     <button
+      *ngIf="selections.length > 1"
       mat-icon-button
       aria-label="Next"
       (click)="next()"
@@ -23,7 +25,7 @@
       <mat-icon>chevron_right</mat-icon>
     </button>
   </div>
-  <div class="selection-count">
+  <div class="selection-count" *ngIf="selections.length > 1">
     {{ selections.length ? currentIndex + 1 : 0 }} / {{ selections.length }}
   </div>
 </div>

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -1,0 +1,1 @@
+<p>multiselect-info-window works!</p>

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -7,7 +7,7 @@
       [disabled]="currentIndex === 0 || selections.length === 0">
       <mat-icon>chevron_left</mat-icon>
     </button>
-    <div *ngIf="currentSelection">
+    <div *ngIf="currentSelection" class="selection-window">
       @switch (currentSelection.type) { @case ('VEHICLE') {
       <app-vehicle-info-window [vehicleId]="currentSelection.id"></app-vehicle-info-window>
       } @case ('VISIT_REQUEST') {

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -9,12 +9,16 @@
       <mat-icon>chevron_left</mat-icon>
     </button>
     <div class="selection-window">
-      @switch (currentSelection?.type) { @case ('VEHICLE') {
-      <app-vehicle-info-window [vehicleId]="currentSelection.id"></app-vehicle-info-window>
-      } @case ('VISIT_REQUEST') {
-      <app-visit-request-info-window
-        [visitRequestId]="currentSelection.id"></app-visit-request-info-window>
-      } }
+      @for (selection of selections; track selection.id; let i = $index) {
+      <div class="selection-item" [class.active]="i === currentIndex">
+        @switch (selection.type) { @case ('VEHICLE') {
+        <app-vehicle-info-window [vehicleId]="selection.id"></app-vehicle-info-window>
+        } @case ('VISIT_REQUEST') {
+        <app-visit-request-info-window
+          [visitRequestId]="selection.id"></app-visit-request-info-window>
+        } }
+      </div>
+      }
     </div>
     <button
       *ngIf="selections.length > 1"

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -6,7 +6,7 @@
     [disabled]="currentIndex === 0 || selections.length === 0">
     <mat-icon>chevron_left</mat-icon>
   </button>
-  <div>
+  <div *ngIf="currentSelection">
     @switch (currentSelection.type) { @case ('VEHICLE') {
     <app-vehicle-info-window [vehicleId]="currentSelection.id"></app-vehicle-info-window>
     } @case ('VISIT_REQUEST') {

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -11,7 +11,8 @@
       @switch (currentSelection?.type) { @case ('VEHICLE') {
       <app-vehicle-info-window [vehicleId]="currentSelection.id"></app-vehicle-info-window>
       } @case ('VISIT_REQUEST') {
-      <div>TODO: visit request</div>
+      <app-visit-request-info-window
+        [visitRequestId]="currentSelection.id"></app-visit-request-info-window>
       } }
     </div>
     <button

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.html
@@ -1,12 +1,23 @@
-<div class="info-window-containers">
-  <div *ngFor="let selection of selections">
-      @switch (selection.type) {
-          @case ('VEHICLE') {
-            <app-vehicle-info-window [vehicleId]="selection.id"></app-vehicle-info-window>
-          }
-          @case ('VISIT_REQUEST') {
-            <div>TODO: visit request</div>
-          }
-      }
+<div class="windows-container">
+  <button
+    mat-icon-button
+    aria-label="Previous"
+    (click)="previous()"
+    [disabled]="currentIndex === 0 || selections.length === 0">
+    <mat-icon>chevron_left</mat-icon>
+  </button>
+  <div>
+    @switch (currentSelection.type) { @case ('VEHICLE') {
+    <app-vehicle-info-window [vehicleId]="currentSelection.id"></app-vehicle-info-window>
+    } @case ('VISIT_REQUEST') {
+    <div>TODO: visit request</div>
+    } }
   </div>
+  <button
+    mat-icon-button
+    aria-label="Next"
+    (click)="next()"
+    [disabled]="currentIndex === selections.length - 1 || selections.length === 0">
+    <mat-icon>chevron_right</mat-icon>
+  </button>
 </div>

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
@@ -1,0 +1,5 @@
+.windows-container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
@@ -12,11 +12,18 @@
   flex-direction: column;
   align-items: center;
   gap: 1rem;
-  min-width: 365px;
 }
 
 .selection-window {
   flex-grow: 1;
+
+  app-vehicle-info-window {
+    min-width: 255px;
+  }
+
+  app-visit-request-info-window {
+    min-width: 175px;
+  }
 }
 
 .selection-count {

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
@@ -4,6 +4,7 @@
   display: flex;
   align-items: center;
   gap: 1rem;
+  width: 100%;
 }
 
 .window-container {
@@ -11,6 +12,11 @@
   flex-direction: column;
   align-items: center;
   gap: 1rem;
+  min-width: 365px;
+}
+
+.selection-window {
+  flex-grow: 1;
 }
 
 .selection-count {

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
@@ -1,5 +1,18 @@
-.windows-container {
+@import '../../../../styles/variables.scss';
+
+.info-container {
   display: flex;
   align-items: center;
   gap: 1rem;
+}
+
+.window-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.selection-count {
+  color: $gray;
 }

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.scss
@@ -16,13 +16,15 @@
 
 .selection-window {
   flex-grow: 1;
+  display: grid;
 
-  app-vehicle-info-window {
-    min-width: 255px;
-  }
+  .selection-item {
+    grid-area: 1 / 1;
+    visibility: hidden;
 
-  app-visit-request-info-window {
-    min-width: 175px;
+    &.active {
+      visibility: visible;
+    }
   }
 }
 

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.spec.ts
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.spec.ts
@@ -8,7 +8,7 @@ describe('MultiselectInfoWindowComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MultiselectInfoWindowComponent],
+      declarations: [MultiselectInfoWindowComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MultiselectInfoWindowComponent);

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.spec.ts
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MultiselectInfoWindowComponent } from './multiselect-info-window.component';
+
+describe('MultiselectInfoWindowComponent', () => {
+  let component: MultiselectInfoWindowComponent;
+  let fixture: ComponentFixture<MultiselectInfoWindowComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MultiselectInfoWindowComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MultiselectInfoWindowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.ts
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
 import { MapSelection } from '../../models/map';
 
 @Component({
@@ -7,6 +14,29 @@ import { MapSelection } from '../../models/map';
   styleUrl: './multiselect-info-window.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MultiselectInfoWindowComponent {
-  selections: MapSelection[] = [];
+export class MultiselectInfoWindowComponent implements OnChanges {
+  @Input() selections: MapSelection[] = [];
+
+  currentIndex: number = 0;
+  currentSelection?: MapSelection;
+
+  constructor(private detectorRef: ChangeDetectorRef) {}
+
+  ngOnChanges(_changes: SimpleChanges): void {
+    this.currentIndex = 0;
+    this.currentSelection = this.selections[this.currentIndex];
+    this.detectorRef.markForCheck();
+  }
+
+  previous(): void {
+    this.currentIndex -= 1;
+    this.currentSelection = this.selections[this.currentIndex];
+    this.detectorRef.markForCheck();
+  }
+
+  next(): void {
+    this.currentIndex += 1;
+    this.currentSelection = this.selections[this.currentIndex];
+    this.detectorRef.markForCheck();
+  }
 }

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.ts
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MapSelection } from '../../models/map';
 
 @Component({
   selector: 'app-multiselect-info-window',
@@ -6,4 +7,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   styleUrl: './multiselect-info-window.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MultiselectInfoWindowComponent {}
+export class MultiselectInfoWindowComponent {
+  selections: MapSelection[] = [];
+}

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.ts
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-multiselect-info-window',
+  templateUrl: './multiselect-info-window.component.html',
+  styleUrl: './multiselect-info-window.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MultiselectInfoWindowComponent {}

--- a/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.ts
+++ b/application/frontend/src/app/core/containers/multiselect-info-window/multiselect-info-window.component.ts
@@ -23,6 +23,9 @@ export class MultiselectInfoWindowComponent implements OnChanges {
   constructor(private detectorRef: ChangeDetectorRef) {}
 
   ngOnChanges(_changes: SimpleChanges): void {
+    if (this.selections.length === 0) {
+      return;
+    }
     this.currentIndex = 0;
     this.currentSelection = this.selections[this.currentIndex];
     this.detectorRef.markForCheck();

--- a/application/frontend/src/app/core/containers/vehicle-info-window/vehicle-info-window.component.ts
+++ b/application/frontend/src/app/core/containers/vehicle-info-window/vehicle-info-window.component.ts
@@ -14,7 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import * as fromRoot from 'src/app/reducers';
@@ -33,20 +40,32 @@ import ShipmentModelSelectors from '../../selectors/shipment-model.selectors';
   styleUrls: ['./vehicle-info-window.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class VehicleInfoWindowComponent implements OnInit {
-  @Input() vehicleId: number;
+export class VehicleInfoWindowComponent implements OnInit, OnChanges {
+  @Input() vehicleId!: number;
 
-  page$: Observable<Page>;
-  route$: Observable<ShipmentRoute>;
-  vehicle$: Observable<Vehicle>;
-  shipmentCount$: Observable<number>;
-  timezoneOffset$: Observable<number>;
-  globalDuration$: Observable<[Long, Long]>;
+  page$?: Observable<Page>;
+  route$?: Observable<ShipmentRoute | undefined>;
+  vehicle$?: Observable<Vehicle | undefined>;
+  shipmentCount$?: Observable<number | undefined>;
+  timezoneOffset$?: Observable<number>;
+  globalDuration$?: Observable<[Long, Long]>;
 
   constructor(private store: Store<fromRoot.State>) {}
 
   ngOnInit(): void {
     this.page$ = this.store.pipe(select(selectPage));
+    this.timezoneOffset$ = this.store.pipe(select(fromConfig.selectTimezoneOffset));
+    this.globalDuration$ = this.store.pipe(select(ShipmentModelSelectors.selectGlobalDuration));
+    this.updateVehicleObservables();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['vehicleId'] && !changes['vehicleId'].firstChange) {
+      this.updateVehicleObservables();
+    }
+  }
+
+  private updateVehicleObservables(): void {
     this.route$ = this.store.pipe(
       select(ShipmentRouteSelectors.selectRoutesByIds([this.vehicleId])),
       map((routes) => routes[this.vehicleId])
@@ -55,8 +74,6 @@ export class VehicleInfoWindowComponent implements OnInit {
     this.shipmentCount$ = this.store.pipe(
       select(ShipmentRouteSelectors.selectRouteShipmentCount(this.vehicleId))
     );
-    this.timezoneOffset$ = this.store.pipe(select(fromConfig.selectTimezoneOffset));
-    this.globalDuration$ = this.store.pipe(select(ShipmentModelSelectors.selectGlobalDuration));
   }
 
   onVehicleClick(vehicle: Vehicle): void {

--- a/application/frontend/src/app/core/core.module.ts
+++ b/application/frontend/src/app/core/core.module.ts
@@ -84,6 +84,7 @@ import {
   VehiclesControlBarComponent,
   VehiclesKpisComponent,
   VisitRequestInfoWindowComponent,
+  MultiselectInfoWindowComponent,
 } from './containers';
 import { DownloadPdfDialogComponent } from './containers/download-pdf-dialog/download-pdf-dialog.component';
 import { PdfMapComponent } from './containers/pdf-map/pdf-map.component';
@@ -148,6 +149,7 @@ export const CONTAINERS = [
   MapComponent,
   MapWrapperComponent,
   MetadataControlBarComponent,
+  MultiselectInfoWindowComponent,
   PostSolveMessageComponent,
   PostSolveMetricsComponent,
   PreSolveControlBarComponent,

--- a/application/frontend/src/app/core/models/map.ts
+++ b/application/frontend/src/app/core/models/map.ts
@@ -28,3 +28,8 @@ export interface MapLayer {
   visible?: boolean;
   travelMode?: TravelMode;
 }
+
+export interface MapSelection {
+  id: number | string;
+  type: 'VEHICLE' | 'VISIT_REQUEST';
+}

--- a/application/frontend/src/app/core/reducers/map.reducer.ts
+++ b/application/frontend/src/app/core/reducers/map.reducer.ts
@@ -23,6 +23,7 @@ export const mapFeatureKey = 'map';
 
 export interface State {
   visibleMapLayers: { [id in MapLayerId]: MapLayer };
+  zoom: number;
 }
 
 export const initialState: State = {
@@ -45,6 +46,7 @@ export const initialState: State = {
       travelMode: TravelMode.WALKING,
     },
   },
+  zoom: 12,
 };
 
 export const reducer = createReducer(
@@ -58,8 +60,14 @@ export const reducer = createReducer(
         visible,
       },
     },
+  })),
+  on(MapActions.setZoomLevel, (state, { zoom }) => ({
+    ...state,
+    zoom,
   }))
 );
 
 export const selectVisibleMapLayers = (state: State): { [id in MapLayerId]: MapLayer } =>
   state.visibleMapLayers;
+
+export const selectZoom = (state: State): number => state.zoom;

--- a/application/frontend/src/app/core/reducers/ui.reducer.ts
+++ b/application/frontend/src/app/core/reducers/ui.reducer.ts
@@ -32,7 +32,7 @@ import {
   UndoRedoActions,
   UploadActions,
 } from '../actions';
-import { Modal, Page } from '../models';
+import { ILatLng, Modal, Page } from '../models';
 import { ScenarioPlanningActions } from 'src/app/scenario-planning/actions';
 
 export const uiFeatureKey = 'ui';
@@ -40,6 +40,7 @@ export const uiFeatureKey = 'ui';
 export interface State {
   clickedMapVehicleId?: number;
   clickedMapVisitRequestId?: number;
+  clickedPosition?: ILatLng;
   hasMap: boolean;
   modal?: Modal;
   mouseOverId?: number;
@@ -51,6 +52,7 @@ export interface State {
 export const initialState: State = {
   clickedMapVehicleId: null,
   clickedMapVisitRequestId: null,
+  clickedPosition: null,
   hasMap: true,
   modal: null,
   mouseOverId: null,
@@ -98,6 +100,10 @@ export const reducer = createReducer(
     ...state,
     clickedMapVisitRequestId: id,
   })),
+  on(UIActions.mapMarkerClicked, (state, { position }) => ({
+    ...state,
+    clickedPosition: position,
+  })),
   on(
     PreSolveShipmentActions.showOnMap,
     PreSolveVehicleActions.showOnMap,
@@ -131,6 +137,8 @@ export const reducer = createReducer(
 export const selectClickedVehicleId = (state: State): number => state.clickedMapVehicleId;
 
 export const selectClickedVisitRequestId = (state: State): number => state.clickedMapVisitRequestId;
+
+export const selectClickedPosition = (state: State): ILatLng => state.clickedPosition;
 
 export const selectModal = (state: State): Modal => state.modal;
 

--- a/application/frontend/src/app/core/selectors/map.selectors.ts
+++ b/application/frontend/src/app/core/selectors/map.selectors.ts
@@ -41,7 +41,7 @@ import * as fromVehicle from './vehicle.selectors';
 import VisitSelectors from './visit.selectors';
 import VisitRequestSelectors from './visit-request.selectors';
 import * as fromMap from '../reducers/map.reducer';
-import { MapLayer, MapLayerId } from '../models/map';
+import { MapLayer, MapLayerId, MapSelection } from '../models/map';
 import TravelSimulatorSelectors from './travel-simulator.selectors';
 import * as fromShipmentRoute from './shipment-route.selectors';
 import Long from 'long';
@@ -356,8 +356,9 @@ export const selectClickedObjects = createSelector(
   selectPage,
   selectClickedPosition,
   fromVehicle.selectAll,
-  (page, position, vehicles) => {
-    const selections: Vehicle[] = [];
+  selectVehicleLocationsOnRouteWithHeadings,
+  (page, position, vehicles, routeLocations) => {
+    const selections: MapSelection[] = [];
 
     if (!position) {
       return {
@@ -380,12 +381,13 @@ export const selectClickedObjects = createSelector(
             fromDispatcherLatLng(startLatLng)
           ) <= coincidentMarkerDistanceMeters
         ) {
-          selections.push(vehicle);
+          selections.push({ id: vehicle.id, type: 'VEHICLE' });
         }
       });
     }
     // Is on post-solve view
     else {
+      Object.keys(routeLocations).forEach((id) => {});
     }
     return { position, selections };
   }

--- a/application/frontend/src/app/core/selectors/map.selectors.ts
+++ b/application/frontend/src/app/core/selectors/map.selectors.ts
@@ -45,6 +45,7 @@ import { MapLayer, MapLayerId, MapSelection } from '../models/map';
 import TravelSimulatorSelectors from './travel-simulator.selectors';
 import * as fromShipmentRoute from './shipment-route.selectors';
 import Long from 'long';
+import * as fromVisitRequests from './visit-request.selectors';
 
 type MapLatLng = google.maps.LatLng;
 
@@ -357,8 +358,10 @@ export const selectClickedObjects = createSelector(
   selectClickedPosition,
   fromVehicle.selectAll,
   selectVehicleLocationsOnRouteWithHeadings,
-  (page, position, vehicles, routeLocations) => {
+  fromVisitRequests.selectEntities,
+  (page, position, vehicles, routeLocations, visitRequests) => {
     const selections: MapSelection[] = [];
+    const isOnPreSolve = [Page.Shipments, Page.Vehicles, Page.ScenarioPlanning].includes(page);
 
     if (!position) {
       return {
@@ -368,7 +371,20 @@ export const selectClickedObjects = createSelector(
     }
 
     const clickLatLng = fromDispatcherLatLng(position);
-    const isOnPreSolve = [Page.Shipments, Page.Vehicles, Page.ScenarioPlanning].includes(page);
+
+    Object.keys(visitRequests)
+      .filter((id) => !!visitRequests[id]?.arrivalWaypoint?.location?.latLng)
+      .forEach((id) => {
+        if (
+          google.maps.geometry.spherical.computeDistanceBetween(
+            clickLatLng,
+            fromDispatcherLatLng(visitRequests[id]!.arrivalWaypoint!.location!.latLng!)
+          ) <= coincidentMarkerDistanceMeters
+        ) {
+          selections.push({ id, type: 'VISIT_REQUEST' });
+        }
+      });
+
     const vehiclesToCheck: { id: string | number; latLng: ILatLng }[] = isOnPreSolve
       ? vehicles
           .filter((vehicle) => !!vehicle.startWaypoint?.location?.latLng)

--- a/application/frontend/src/app/core/selectors/map.selectors.ts
+++ b/application/frontend/src/app/core/selectors/map.selectors.ts
@@ -30,13 +30,13 @@ import {
   toTurfLineString,
   toTurfPoint,
 } from 'src/app/util';
-import { ILatLng, Page, TravelMode, ShipmentRoute, VisitRequest } from '../models';
+import { ILatLng, Page, TravelMode, ShipmentRoute, VisitRequest, Vehicle } from '../models';
 import * as fromDepot from './depot.selectors';
 import PreSolveShipmentSelectors from './pre-solve-shipment.selectors';
 import PreSolveVehicleSelectors from './pre-solve-vehicle.selectors';
 import RoutesChartSelectors from './routes-chart.selectors';
 import ShipmentRouteSelectors from './shipment-route.selectors';
-import { selectPage } from './ui.selectors';
+import { selectClickedPosition, selectPage } from './ui.selectors';
 import * as fromVehicle from './vehicle.selectors';
 import VisitSelectors from './visit.selectors';
 import VisitRequestSelectors from './visit-request.selectors';
@@ -47,6 +47,8 @@ import * as fromShipmentRoute from './shipment-route.selectors';
 import Long from 'long';
 
 type MapLatLng = google.maps.LatLng;
+
+const coincidentMarkerDistanceMeters = 3.0;
 
 export const selectMapState = createFeatureSelector<fromMap.State>(fromMap.mapFeatureKey);
 
@@ -347,5 +349,44 @@ export const selectUsedMapLayers = createSelector(
     });
 
     return mapLayers;
+  }
+);
+
+export const selectClickedObjects = createSelector(
+  selectPage,
+  selectClickedPosition,
+  fromVehicle.selectAll,
+  (page, position, vehicles) => {
+    const selections: Vehicle[] = [];
+
+    if (!position) {
+      return {
+        position: null,
+        selections: selections,
+      };
+    }
+
+    const clickLatLng = fromDispatcherLatLng(position);
+    // Is on pre-solve view
+    if ([Page.Shipments, Page.Vehicles, Page.ScenarioPlanning].includes(page)) {
+      vehicles.forEach((vehicle) => {
+        const startLatLng = vehicle.startWaypoint?.location?.latLng;
+        if (!startLatLng) {
+          return;
+        }
+        if (
+          google.maps.geometry.spherical.computeDistanceBetween(
+            clickLatLng,
+            fromDispatcherLatLng(startLatLng)
+          ) <= coincidentMarkerDistanceMeters
+        ) {
+          selections.push(vehicle);
+        }
+      });
+    }
+    // Is on post-solve view
+    else {
+    }
+    return { position, selections };
   }
 );

--- a/application/frontend/src/app/core/selectors/map.selectors.ts
+++ b/application/frontend/src/app/core/selectors/map.selectors.ts
@@ -30,7 +30,7 @@ import {
   toTurfLineString,
   toTurfPoint,
 } from 'src/app/util';
-import { ILatLng, Page, TravelMode, ShipmentRoute, VisitRequest, Vehicle } from '../models';
+import { ILatLng, Page, TravelMode, ShipmentRoute, VisitRequest } from '../models';
 import * as fromDepot from './depot.selectors';
 import PreSolveShipmentSelectors from './pre-solve-shipment.selectors';
 import PreSolveVehicleSelectors from './pre-solve-vehicle.selectors';
@@ -49,9 +49,15 @@ import * as fromVisitRequests from './visit-request.selectors';
 
 type MapLatLng = google.maps.LatLng;
 
-const coincidentMarkerDistanceMeters = 3.0;
-
 export const selectMapState = createFeatureSelector<fromMap.State>(fromMap.mapFeatureKey);
+
+export const selectZoom = createSelector(selectMapState, fromMap.selectZoom);
+
+// Calculate the appropriate multi-selection distance in meters based on the current zoom level
+export const selectSelectionDistanceMeters = createSelector(selectZoom, (zoom: number): number => {
+  const distance = 3 * Math.pow(2, 19 - zoom);
+  return Math.max(1, Math.min(500000, distance));
+});
 
 const findAlternativeStartLocation = (path: MapLatLng[]): MapLatLng => {
   const distanceAlongPath = google.maps.geometry.spherical.computeLength(path) / 10;
@@ -359,7 +365,8 @@ export const selectClickedObjects = createSelector(
   fromVehicle.selectAll,
   selectVehicleLocationsOnRouteWithHeadings,
   fromVisitRequests.selectAll,
-  (page, position, vehicles, routeLocations, visitRequests) => {
+  selectSelectionDistanceMeters,
+  (page, position, vehicles, routeLocations, visitRequests, selectionDistanceMeters) => {
     const selections: MapSelection[] = [];
     const isOnPreSolve = [Page.Shipments, Page.Vehicles, Page.ScenarioPlanning].includes(page);
 
@@ -379,7 +386,7 @@ export const selectClickedObjects = createSelector(
           google.maps.geometry.spherical.computeDistanceBetween(
             clickLatLng,
             fromDispatcherLatLng(vr.arrivalWaypoint!.location!.latLng!)
-          ) <= coincidentMarkerDistanceMeters
+          ) <= selectionDistanceMeters
         ) {
           selections.push({ id: vr.id, type: 'VISIT_REQUEST' });
         }
@@ -404,7 +411,7 @@ export const selectClickedObjects = createSelector(
         google.maps.geometry.spherical.computeDistanceBetween(
           clickLatLng,
           fromDispatcherLatLng(vehicle.latLng)
-        ) <= coincidentMarkerDistanceMeters
+        ) <= selectionDistanceMeters
       ) {
         selections.push({ id: vehicle.id, type: 'VEHICLE' });
       }

--- a/application/frontend/src/app/core/selectors/map.selectors.ts
+++ b/application/frontend/src/app/core/selectors/map.selectors.ts
@@ -368,27 +368,32 @@ export const selectClickedObjects = createSelector(
     }
 
     const clickLatLng = fromDispatcherLatLng(position);
-    // Is on pre-solve view
-    if ([Page.Shipments, Page.Vehicles, Page.ScenarioPlanning].includes(page)) {
-      vehicles.forEach((vehicle) => {
-        const startLatLng = vehicle.startWaypoint?.location?.latLng;
-        if (!startLatLng) {
-          return;
-        }
-        if (
-          google.maps.geometry.spherical.computeDistanceBetween(
-            clickLatLng,
-            fromDispatcherLatLng(startLatLng)
-          ) <= coincidentMarkerDistanceMeters
-        ) {
-          selections.push({ id: vehicle.id, type: 'VEHICLE' });
-        }
-      });
-    }
-    // Is on post-solve view
-    else {
-      Object.keys(routeLocations).forEach((id) => {});
-    }
+    const isOnPreSolve = [Page.Shipments, Page.Vehicles, Page.ScenarioPlanning].includes(page);
+    const vehiclesToCheck: { id: string | number; latLng: ILatLng }[] = isOnPreSolve
+      ? vehicles
+          .filter((vehicle) => !!vehicle.startWaypoint?.location?.latLng)
+          .map((vehicle) => ({ id: vehicle.id, latLng: vehicle.startWaypoint!.location!.latLng }))
+      : Object.keys(routeLocations)
+          .filter((id) => !!routeLocations[id].location)
+          .map((id) => ({
+            id,
+            latLng: {
+              latitude: routeLocations[id].location.lat(),
+              longitude: routeLocations[id].location.lng(),
+            },
+          }));
+
+    vehiclesToCheck.forEach((vehicle) => {
+      if (
+        google.maps.geometry.spherical.computeDistanceBetween(
+          clickLatLng,
+          fromDispatcherLatLng(vehicle.latLng)
+        ) <= coincidentMarkerDistanceMeters
+      ) {
+        selections.push({ id: vehicle.id, type: 'VEHICLE' });
+      }
+    });
+
     return { position, selections };
   }
 );

--- a/application/frontend/src/app/core/selectors/map.selectors.ts
+++ b/application/frontend/src/app/core/selectors/map.selectors.ts
@@ -358,7 +358,7 @@ export const selectClickedObjects = createSelector(
   selectClickedPosition,
   fromVehicle.selectAll,
   selectVehicleLocationsOnRouteWithHeadings,
-  fromVisitRequests.selectEntities,
+  fromVisitRequests.selectAll,
   (page, position, vehicles, routeLocations, visitRequests) => {
     const selections: MapSelection[] = [];
     const isOnPreSolve = [Page.Shipments, Page.Vehicles, Page.ScenarioPlanning].includes(page);
@@ -372,30 +372,30 @@ export const selectClickedObjects = createSelector(
 
     const clickLatLng = fromDispatcherLatLng(position);
 
-    Object.keys(visitRequests)
-      .filter((id) => !!visitRequests[id]?.arrivalWaypoint?.location?.latLng)
-      .forEach((id) => {
+    visitRequests
+      .filter((vr) => !!vr.arrivalWaypoint?.location?.latLng)
+      .forEach((vr) => {
         if (
           google.maps.geometry.spherical.computeDistanceBetween(
             clickLatLng,
-            fromDispatcherLatLng(visitRequests[id]!.arrivalWaypoint!.location!.latLng!)
+            fromDispatcherLatLng(vr.arrivalWaypoint!.location!.latLng!)
           ) <= coincidentMarkerDistanceMeters
         ) {
-          selections.push({ id, type: 'VISIT_REQUEST' });
+          selections.push({ id: vr.id, type: 'VISIT_REQUEST' });
         }
       });
 
     const vehiclesToCheck: { id: string | number; latLng: ILatLng }[] = isOnPreSolve
       ? vehicles
           .filter((vehicle) => !!vehicle.startWaypoint?.location?.latLng)
-          .map((vehicle) => ({ id: vehicle.id, latLng: vehicle.startWaypoint!.location!.latLng }))
-      : Object.keys(routeLocations)
-          .filter((id) => !!routeLocations[id].location)
-          .map((id) => ({
-            id,
+          .map((vehicle) => ({ id: vehicle.id, latLng: vehicle.startWaypoint!.location!.latLng! }))
+      : Object.entries(routeLocations)
+          .filter(([, loc]) => !!loc.location)
+          .map(([id, loc]) => ({
+            id: +id,
             latLng: {
-              latitude: routeLocations[id].location.lat(),
-              longitude: routeLocations[id].location.lng(),
+              latitude: loc.location.lat(),
+              longitude: loc.location.lng(),
             },
           }));
 

--- a/application/frontend/src/app/core/selectors/ui.selectors.ts
+++ b/application/frontend/src/app/core/selectors/ui.selectors.ts
@@ -46,3 +46,5 @@ export const selectOpenUploadDialogOnClose = createSelector(
   selectUIState,
   fromUI.selectOpenUploadDialogOnClose
 );
+
+export const selectClickedPosition = createSelector(selectUIState, fromUI.selectClickedPosition);

--- a/application/frontend/src/app/core/selectors/ui.selectors.ts
+++ b/application/frontend/src/app/core/selectors/ui.selectors.ts
@@ -48,3 +48,7 @@ export const selectOpenUploadDialogOnClose = createSelector(
 );
 
 export const selectClickedPosition = createSelector(selectUIState, fromUI.selectClickedPosition);
+
+export const selectIsPreSolve = createSelector(selectPage, (page) =>
+  [Page.Shipments, Page.Vehicles, Page.ScenarioPlanning].includes(page)
+);

--- a/application/frontend/src/app/core/services/base-markers-layer.service.ts
+++ b/application/frontend/src/app/core/services/base-markers-layer.service.ts
@@ -31,6 +31,7 @@ export abstract class BaseMarkersLayer {
   );
   readonly dragEnd$ = new Subject<{ id: number | string; pos: google.maps.LatLng }>();
   readonly edit$ = new Subject<{ id: number | string; pos: google.maps.LatLng }>();
+  readonly click$ = new Subject<{ id: number | string; pos: google.maps.LatLng }>();
 
   protected markers = new Map<number | string, google.maps.Marker>();
   protected listeners = new Map<
@@ -40,6 +41,7 @@ export abstract class BaseMarkersLayer {
   protected abstract zIndex: number;
   private _visible = false;
   private _draggable = false;
+  private _clickable = false;
 
   get visible(): boolean {
     return this._visible;
@@ -59,6 +61,15 @@ export abstract class BaseMarkersLayer {
   set draggable(value: boolean) {
     this._draggable = value;
     Array.from(this.markers.keys()).forEach((id) => this.setDraggable(id, value));
+  }
+
+  get clickable(): boolean {
+    return this._clickable;
+  }
+
+  set clickable(value: boolean) {
+    this._clickable = value;
+    Array.from(this.markers.keys()).forEach((id) => this.setClickable(id, value));
   }
 
   constructor(
@@ -179,6 +190,26 @@ export abstract class BaseMarkersLayer {
       'dragend',
       (event: google.maps.MapMouseEvent) => {
         this.zone.run(() => this.dragEnd$.next({ id, pos: event.latLng }));
+      }
+    );
+  }
+
+  protected setClickable(id: number | string, clickable: boolean): void {
+    const marker = this.markers.get(id);
+    if (!marker) {
+      return;
+    }
+    marker.setClickable(clickable);
+    const listeners = this.listeners.get(id);
+    listeners.click?.remove();
+    if (!clickable) {
+      return;
+    }
+    listeners.click = google.maps.event.addListener(
+      marker,
+      'click',
+      (event: google.maps.MapMouseEvent) => {
+        this.zone.run(() => this.click$.next({ id, pos: event.latLng }));
       }
     );
   }

--- a/application/frontend/src/app/core/services/base-vehicle-layer.service.ts
+++ b/application/frontend/src/app/core/services/base-vehicle-layer.service.ts
@@ -148,7 +148,11 @@ export abstract class BaseVehicleLayer {
       },
       onClick: ({ object }) => {
         this.zone.run(() => {
-          this.store.dispatch(UIActions.mapVehicleClicked({ id: object.id }));
+          this.store.dispatch(
+            UIActions.mapMarkerClicked({
+              position: { longitude: object.position[0], latitude: object.position[1] },
+            })
+          );
         });
       },
     });

--- a/application/frontend/src/app/core/services/base-visit-request-layer.service.ts
+++ b/application/frontend/src/app/core/services/base-visit-request-layer.service.ts
@@ -162,7 +162,14 @@ export abstract class BaseVisitRequestLayer {
       },
       onClick: ({ object }) => {
         this.zone.run(() => {
-          this.store.dispatch(UIActions.mapVisitRequestClicked({ id: object.id }));
+          this.store.dispatch(
+            UIActions.mapMarkerClicked({
+              position: {
+                longitude: object.arrivalPosition[0],
+                latitude: object.arrivalPosition[1],
+              },
+            })
+          );
         });
       },
     });
@@ -185,7 +192,14 @@ export abstract class BaseVisitRequestLayer {
       },
       onClick: ({ object }) => {
         this.zone.run(() => {
-          this.store.dispatch(UIActions.mapVisitRequestClicked({ id: object.id }));
+          this.store.dispatch(
+            UIActions.mapMarkerClicked({
+              position: {
+                longitude: object.arrivalPosition[0],
+                latitude: object.arrivalPosition[1],
+              },
+            })
+          );
         });
       },
     });

--- a/application/frontend/src/app/core/services/depot-layer.service.ts
+++ b/application/frontend/src/app/core/services/depot-layer.service.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import { Store } from '@ngrx/store';
 import * as fromRoot from 'src/app/reducers';
 import { fromDispatcherLatLng } from 'src/app/util';
@@ -22,6 +22,7 @@ import { ILatLng } from '../models';
 import { BaseMarkersLayer } from './base-markers-layer.service';
 import { ZIndex } from './map-theme.service';
 import { MapService } from './map.service';
+import { UIActions } from '../actions';
 
 @Injectable({
   providedIn: 'root',
@@ -61,8 +62,15 @@ export class DepotLayer extends BaseMarkersLayer {
     this._symbol = value;
   }
 
-  constructor(mapService: MapService, store: Store<fromRoot.State>) {
-    super(mapService, store);
+  constructor(mapService: MapService, store: Store<fromRoot.State>, zone: NgZone) {
+    super(mapService, store, zone);
+    this.click$.subscribe((res) =>
+      store.dispatch(
+        UIActions.mapMarkerClicked({
+          position: { latitude: res.pos.lat(), longitude: res.pos.lng() },
+        })
+      )
+    );
   }
 
   getMarker(): google.maps.Marker {
@@ -74,6 +82,7 @@ export class DepotLayer extends BaseMarkersLayer {
       this.addMarker(this.depotId, this.createMarker(depot));
       this.moveMarker(this.depotId, depot != null ? fromDispatcherLatLng(depot) : null);
       this.draggable = false;
+      this.clickable = true;
       this.show();
     } else {
       this.hide();

--- a/application/frontend/src/app/core/services/index.ts
+++ b/application/frontend/src/app/core/services/index.ts
@@ -25,6 +25,7 @@ export * from './map-api.service';
 export * from './map-theme.service';
 export * from './map.service';
 export * from './message.service';
+export * from './multiselect-info-window-service';
 export * from './normalization.service';
 export * from './optimize-tours-message.service';
 export * from './places.service';

--- a/application/frontend/src/app/core/services/multiselect-info-window-service.ts
+++ b/application/frontend/src/app/core/services/multiselect-info-window-service.ts
@@ -44,17 +44,18 @@ export class MultiselectInfoWindowService extends BaseInfoWindowService<Multisel
   }
 
   open(event: { position: ILatLng | null; selections: MapSelection[] }): void {
-    if (event.position) {
-      this.create(MultiselectInfoWindowComponent);
-      this.componentRef.setInput('selections', event.selections);
-      this.infoWindow.setPosition({
-        lat: event.position.latitude,
-        lng: event.position.longitude,
-      });
-      this.infoWindow.open(this.mapService.map);
-    } else {
+    if (!event.position || event.selections.length === 0) {
       this.clear();
+      return;
     }
+
+    this.create(MultiselectInfoWindowComponent);
+    this.componentRef.setInput('selections', event.selections);
+    this.infoWindow.setPosition({
+      lat: event.position.latitude,
+      lng: event.position.longitude,
+    });
+    this.infoWindow.open(this.mapService.map);
   }
 
   onClose(): void {

--- a/application/frontend/src/app/core/services/multiselect-info-window-service.ts
+++ b/application/frontend/src/app/core/services/multiselect-info-window-service.ts
@@ -44,7 +44,7 @@ export class MultiselectInfoWindowService extends BaseInfoWindowService<Multisel
   open(event: { position: ILatLng | null; selections: MapSelection[] }): void {
     if (event.position) {
       this.create(MultiselectInfoWindowComponent);
-      this.componentRef.instance.selections = event.selections;
+      this.componentRef.setInput('selections', event.selections);
       this.infoWindow.setPosition({
         lat: event.position.latitude,
         lng: event.position.longitude,

--- a/application/frontend/src/app/core/services/multiselect-info-window-service.ts
+++ b/application/frontend/src/app/core/services/multiselect-info-window-service.ts
@@ -46,6 +46,7 @@ export class MultiselectInfoWindowService extends BaseInfoWindowService<Multisel
   open(event: { position: ILatLng | null; selections: MapSelection[] }): void {
     if (!event.position || event.selections.length === 0) {
       this.clear();
+      this.onClose();
       return;
     }
 

--- a/application/frontend/src/app/core/services/multiselect-info-window-service.ts
+++ b/application/frontend/src/app/core/services/multiselect-info-window-service.ts
@@ -24,6 +24,7 @@ import { UIActions } from '../actions';
 import { ILatLng, Vehicle } from '../models';
 import { MultiselectInfoWindowComponent } from '../containers/multiselect-info-window/multiselect-info-window.component';
 import { MapSelection } from '../models/map';
+import { selectIsPreSolve } from '../selectors/ui.selectors';
 
 /** Manages lifecycle of vehicle info windows */
 @Injectable({
@@ -39,6 +40,7 @@ export class MultiselectInfoWindowService extends BaseInfoWindowService<Multisel
     super(injector, applicationRef);
 
     this.store.pipe(select(selectClickedObjects)).subscribe((selection) => this.open(selection));
+    this.store.pipe(select(selectIsPreSolve)).subscribe((_isPreSolve) => this.onClose());
   }
 
   open(event: { position: ILatLng | null; selections: MapSelection[] }): void {

--- a/application/frontend/src/app/core/services/multiselect-info-window-service.ts
+++ b/application/frontend/src/app/core/services/multiselect-info-window-service.ts
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ApplicationRef, EnvironmentInjector, Injectable } from '@angular/core';
+import { select, Store } from '@ngrx/store';
+import { State } from 'src/app/reducers';
+import { selectClickedObjects } from '../selectors/map.selectors';
+import { BaseInfoWindowService } from './base-info-window.service';
+import { MapService } from './map.service';
+import { UIActions } from '../actions';
+import { ILatLng, Vehicle } from '../models';
+import { MultiselectInfoWindowComponent } from '../containers/multiselect-info-window/multiselect-info-window.component';
+
+/** Manages lifecycle of vehicle info windows */
+@Injectable({
+  providedIn: 'root',
+})
+export class MultiselectInfoWindowService extends BaseInfoWindowService<MultiselectInfoWindowComponent> {
+  constructor(
+    injector: EnvironmentInjector,
+    applicationRef: ApplicationRef,
+    private mapService: MapService,
+    private store: Store<State>
+  ) {
+    super(injector, applicationRef);
+
+    this.store.pipe(select(selectClickedObjects)).subscribe((selection) => this.open(selection));
+  }
+
+  open(selection: { position: ILatLng | null; selections: Vehicle[] }): void {
+    if (selection.position) {
+      this.create(MultiselectInfoWindowComponent);
+      this.infoWindow.setPosition({
+        lat: selection.position.latitude,
+        lng: selection.position.longitude,
+      });
+      this.infoWindow.open(this.mapService.map);
+    } else {
+      this.clear();
+    }
+  }
+
+  onClose(): void {
+    this.store.dispatch(UIActions.mapMarkerClicked({ position: null }));
+    super.onClose();
+  }
+}

--- a/application/frontend/src/app/core/services/multiselect-info-window-service.ts
+++ b/application/frontend/src/app/core/services/multiselect-info-window-service.ts
@@ -23,6 +23,7 @@ import { MapService } from './map.service';
 import { UIActions } from '../actions';
 import { ILatLng, Vehicle } from '../models';
 import { MultiselectInfoWindowComponent } from '../containers/multiselect-info-window/multiselect-info-window.component';
+import { MapSelection } from '../models/map';
 
 /** Manages lifecycle of vehicle info windows */
 @Injectable({
@@ -40,12 +41,13 @@ export class MultiselectInfoWindowService extends BaseInfoWindowService<Multisel
     this.store.pipe(select(selectClickedObjects)).subscribe((selection) => this.open(selection));
   }
 
-  open(selection: { position: ILatLng | null; selections: Vehicle[] }): void {
-    if (selection.position) {
+  open(event: { position: ILatLng | null; selections: MapSelection[] }): void {
+    if (event.position) {
       this.create(MultiselectInfoWindowComponent);
+      this.componentRef.instance.selections = event.selections;
       this.infoWindow.setPosition({
-        lat: selection.position.latitude,
-        lng: selection.position.longitude,
+        lat: event.position.latitude,
+        lng: event.position.longitude,
       });
       this.infoWindow.open(this.mapService.map);
     } else {

--- a/application/frontend/src/app/core/services/post-solve-visit-request-layer.service.ts
+++ b/application/frontend/src/app/core/services/post-solve-visit-request-layer.service.ts
@@ -113,7 +113,14 @@ export class PostSolveVisitRequestLayer extends BaseVisitRequestLayer {
       },
       onClick: ({ object }) => {
         this.zone.run(() => {
-          this.store.dispatch(UIActions.mapVisitRequestClicked({ id: object.id }));
+          this.store.dispatch(
+            UIActions.mapMarkerClicked({
+              position: {
+                longitude: object.arrivalPosition[0],
+                latitude: object.arrivalPosition[1],
+              },
+            })
+          );
         });
       },
     });

--- a/application/frontend/src/app/reducers/undo-redo.ts
+++ b/application/frontend/src/app/reducers/undo-redo.ts
@@ -60,6 +60,7 @@ const ignoreActions = new Set<string>([
   UIActions.changeSplitSizes.type,
   UIActions.mapVehicleClicked.type,
   UIActions.mapVisitRequestClicked.type,
+  UIActions.mapMarkerClicked.type,
   MetadataControlBarActions.addFilter.type,
   MetadataControlBarActions.editFilter.type,
   MetadataControlBarActions.removeFilter.type,


### PR DESCRIPTION
Add support for showing multiple entities in the same info window. On click, scan for all nearby icons and display them in a window that allows the user to scroll through all entities as that location.